### PR TITLE
feat: allowed_extensions instead of allowed_types

### DIFF
--- a/clients/entity-client/src/openapi.d.ts
+++ b/clients/entity-client/src/openapi.d.ts
@@ -854,7 +854,7 @@ declare namespace Components {
                 hook: string;
                 /**
                  * example:
-                 * _is_price_bundle = "false"
+                 * _is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1138,7 +1138,7 @@ declare namespace Components {
                      *   "label": "Price components"
                      *   "value": "{{item.prices.length}} price components"
                      *   "show_as_tag": true
-                     *   "render_condition": "is_price_bundle = \"true\""
+                     *   "render_condition": "is_composite_price = \"true\""
                      * }
                      * ```
                      * The value field supports handlebar expressions from which you can pick any field from the entity state.
@@ -1178,7 +1178,7 @@ declare namespace Components {
                 expanded?: boolean;
                 /**
                  * example:
-                 * _is_price_bundle = "false"
+                 * _is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1344,7 +1344,7 @@ declare namespace Components {
                      *   "label": "Price components"
                      *   "value": "{{item.prices.length}} price components"
                      *   "show_as_tag": true
-                     *   "render_condition": "is_price_bundle = \"true\""
+                     *   "render_condition": "is_composite_price = \"true\""
                      * }
                      * ```
                      * The value field supports handlebar expressions from which you can pick any field from the entity state.
@@ -1384,7 +1384,7 @@ declare namespace Components {
                 expanded?: boolean;
                 /**
                  * example:
-                 * _is_price_bundle = "false"
+                 * _is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1621,9 +1621,9 @@ declare namespace Components {
             type: "image" | "file";
             multiple?: boolean;
             /**
-             * List of unique content type specifiers (mime-types / extension)
+             * List of file extensions (without the dot suffix)
              */
-            allowed_types?: string[];
+            allowed_extensions?: string[];
             default_access_control?: "public-read" | "private";
         }
         export type GetRelationsResp = (RelationItem | /**
@@ -2768,7 +2768,7 @@ declare namespace Components {
          *   "label": "Price components"
          *   "value": "{{item.prices.length}} price components"
          *   "show_as_tag": true
-         *   "render_condition": "is_price_bundle = \"true\""
+         *   "render_condition": "is_composite_price = \"true\""
          * }
          * ```
          * The value field supports handlebar expressions from which you can pick any field from the entity state.

--- a/clients/entity-client/src/openapi.json
+++ b/clients/entity-client/src/openapi.json
@@ -1383,7 +1383,7 @@
                 },
                 "render_condition": {
                   "type": "string",
-                  "example": "_is_price_bundle = \"false\""
+                  "example": "_is_composite_price = \"false\""
                 },
                 "order": {
                   "description": "Render order of the group",
@@ -1950,12 +1950,12 @@
               "multiple": {
                 "type": "boolean"
               },
-              "allowed_types": {
-                "description": "List of unique content type specifiers (mime-types / extension)",
+              "allowed_extensions": {
+                "description": "List of file extensions (without the dot suffix)",
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "example": "image/*"
+                  "example": "csv"
                 }
               },
               "default_access_control": {
@@ -2521,7 +2521,7 @@
         ]
       },
       "SummaryAttribute": {
-        "description": "Represents an expanded version of an attribute to be displayed in the list item summary.\nThis configuration can be used in the following way: \n```js\n{\n  \"label\": \"Price components\"\n  \"value\": \"{{item.prices.length}} price components\"\n  \"show_as_tag\": true\n  \"render_condition\": \"is_price_bundle = \\\"true\\\"\"\n}\n```\nThe value field supports handlebar expressions from which you can pick any field from the entity state. \n",
+        "description": "Represents an expanded version of an attribute to be displayed in the list item summary.\nThis configuration can be used in the following way: \n```js\n{\n  \"label\": \"Price components\"\n  \"value\": \"{{item.prices.length}} price components\"\n  \"show_as_tag\": true\n  \"render_condition\": \"is_composite_price = \\\"true\\\"\"\n}\n```\nThe value field supports handlebar expressions from which you can pick any field from the entity state. \n",
         "type": "object",
         "properties": {
           "label": {
@@ -2588,7 +2588,7 @@
                 },
                 "render_condition": {
                   "type": "string",
-                  "example": "_is_price_bundle = \"false\""
+                  "example": "_is_composite_price = \"false\""
                 },
                 "order": {
                   "type": "integer",


### PR DESCRIPTION
Adds allowed file extensions (`allowed_extensions`) to attribute of type file. Instead of `types` since we were not really supporting content types. 

Also `Content-Types` are a bit to generic when we want to specifically lock on a set of file extensions.