### PR TITLE
refactor: rename Product property _is_price_bundle to is_composite_price

### DIFF
--- a/clients/entity-client/src/openapi.d.ts
+++ b/clients/entity-client/src/openapi.d.ts
@@ -854,7 +854,7 @@ declare namespace Components {
                 hook: string;
                 /**
                  * example:
-                 * _is_price_bundle = "false"
+                 * _is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1138,7 +1138,7 @@ declare namespace Components {
                      *   "label": "Price components"
                      *   "value": "{{item.prices.length}} price components"
                      *   "show_as_tag": true
-                     *   "render_condition": "is_price_bundle = \"true\""
+                     *   "render_condition": "is_composite_price = \"true\""
                      * }
                      * ```
                      * The value field supports handlebar expressions from which you can pick any field from the entity state.
@@ -1178,7 +1178,7 @@ declare namespace Components {
                 expanded?: boolean;
                 /**
                  * example:
-                 * _is_price_bundle = "false"
+                 * _is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1344,7 +1344,7 @@ declare namespace Components {
                      *   "label": "Price components"
                      *   "value": "{{item.prices.length}} price components"
                      *   "show_as_tag": true
-                     *   "render_condition": "is_price_bundle = \"true\""
+                     *   "render_condition": "is_composite_price = \"true\""
                      * }
                      * ```
                      * The value field supports handlebar expressions from which you can pick any field from the entity state.
@@ -1384,7 +1384,7 @@ declare namespace Components {
                 expanded?: boolean;
                 /**
                  * example:
-                 * _is_price_bundle = "false"
+                 * _is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -2768,7 +2768,7 @@ declare namespace Components {
          *   "label": "Price components"
          *   "value": "{{item.prices.length}} price components"
          *   "show_as_tag": true
-         *   "render_condition": "is_price_bundle = \"true\""
+         *   "render_condition": "is_composite_price = \"true\""
          * }
          * ```
          * The value field supports handlebar expressions from which you can pick any field from the entity state.

--- a/clients/entity-client/src/openapi.d.ts
+++ b/clients/entity-client/src/openapi.d.ts
@@ -854,7 +854,7 @@ declare namespace Components {
                 hook: string;
                 /**
                  * example:
-                 * _is_composite_price = "false"
+                 * is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1178,7 +1178,7 @@ declare namespace Components {
                 expanded?: boolean;
                 /**
                  * example:
-                 * _is_composite_price = "false"
+                 * is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**
@@ -1384,7 +1384,7 @@ declare namespace Components {
                 expanded?: boolean;
                 /**
                  * example:
-                 * _is_composite_price = "false"
+                 * is_composite_price = "false"
                  */
                 render_condition?: string;
                 /**

--- a/clients/entity-client/src/openapi.json
+++ b/clients/entity-client/src/openapi.json
@@ -1383,7 +1383,7 @@
                 },
                 "render_condition": {
                   "type": "string",
-                  "example": "_is_composite_price = \"false\""
+                  "example": "is_composite_price = \"false\""
                 },
                 "order": {
                   "description": "Render order of the group",
@@ -2588,7 +2588,7 @@
                 },
                 "render_condition": {
                   "type": "string",
-                  "example": "_is_composite_price = \"false\""
+                  "example": "is_composite_price = \"false\""
                 },
                 "order": {
                   "type": "integer",

--- a/clients/entity-client/src/openapi.json
+++ b/clients/entity-client/src/openapi.json
@@ -1383,7 +1383,7 @@
                 },
                 "render_condition": {
                   "type": "string",
-                  "example": "_is_price_bundle = \"false\""
+                  "example": "_is_composite_price = \"false\""
                 },
                 "order": {
                   "description": "Render order of the group",
@@ -2521,7 +2521,7 @@
         ]
       },
       "SummaryAttribute": {
-        "description": "Represents an expanded version of an attribute to be displayed in the list item summary.\nThis configuration can be used in the following way: \n```js\n{\n  \"label\": \"Price components\"\n  \"value\": \"{{item.prices.length}} price components\"\n  \"show_as_tag\": true\n  \"render_condition\": \"is_price_bundle = \\\"true\\\"\"\n}\n```\nThe value field supports handlebar expressions from which you can pick any field from the entity state. \n",
+        "description": "Represents an expanded version of an attribute to be displayed in the list item summary.\nThis configuration can be used in the following way: \n```js\n{\n  \"label\": \"Price components\"\n  \"value\": \"{{item.prices.length}} price components\"\n  \"show_as_tag\": true\n  \"render_condition\": \"is_composite_price = \\\"true\\\"\"\n}\n```\nThe value field supports handlebar expressions from which you can pick any field from the entity state. \n",
         "type": "object",
         "properties": {
           "label": {
@@ -2588,7 +2588,7 @@
                 },
                 "render_condition": {
                   "type": "string",
-                  "example": "_is_price_bundle = \"false\""
+                  "example": "_is_composite_price = \"false\""
                 },
                 "order": {
                   "type": "integer",


### PR DESCRIPTION
Rename property `_is_price_bundle` to `is_composite_price`, to better follow the industry naming convention.