### PR TITLE
feat: add navbar_actions to schema UI configs

### DIFF
--- a/clients/entity-client/src/openapi.json
+++ b/clients/entity-client/src/openapi.json
@@ -3203,6 +3203,37 @@
               "type": "string"
             }
           },
+          "navbar_actions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "label": {
+                        "type": "string"
+                      },
+                      "params": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "label"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "type"
+              ]
+            }
+          },
           "classic_view": {
             "type": "string",
             "format": "uri"


### PR DESCRIPTION
Adds the ability to customise the "add button" on the entity table view. This is achieved using the new `navbar_actions` key on the UI config. 