### PR TITLE
Feat: Add total_details property CompositePriceItem

### DIFF
--- a/clients/pricing-client/src/openapi.d.ts
+++ b/clients/pricing-client/src/openapi.d.ts
@@ -800,6 +800,7 @@ declare namespace Components {
              * }
              */
             PriceItem[];
+            total_details?: /* The total details with tax (and discount) aggregated totals. */ TotalDetails;
         }
         /**
          * Represents a composite price input to the pricing library.
@@ -2195,7 +2196,14 @@ declare namespace Components {
              *   "$ref": "#/components/examples/price-item"
              * }
              */
-            PriceItem)[];
+            PriceItem | /**
+             * Represents a composite price input to the pricing library.
+             * example:
+             * {
+             *   "$ref": "#/components/examples/price-item"
+             * }
+             */
+            CompositePriceItem)[];
             /**
              * Total of all items before (discounts or) taxes are applied.
              */

--- a/clients/pricing-client/src/openapi.json
+++ b/clients/pricing-client/src/openapi.json
@@ -2458,6 +2458,9 @@
             "items": {
               "$ref": "#/components/schemas/PriceItem"
             }
+          },
+          "total_details": {
+            "$ref": "#/components/schemas/TotalDetails"
           }
         }
       },
@@ -2731,6 +2734,9 @@
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/PriceItem"
+                },
+                {
+                  "$ref": "#/components/schemas/CompositePriceItem"
                 }
               ]
             }


### PR DESCRIPTION
Adding total_details to compositePriceItem properties. In this PR we are also updating `PricingDetails` since it was outdated.