### PR TITLE
Make attribute type required in entity api spec

### DIFF
--- a/clients/entity-client/src/openapi.d.ts
+++ b/clients/entity-client/src/openapi.d.ts
@@ -261,7 +261,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "relation_address";
+            type: "relation_address";
             has_primary?: boolean;
         }
         export type Attribute = /* Textarea or text input */ TextAttribute | /* Link with title and href */ LinkAttribute | /* Date or Datetime picker */ DateAttribute | /* Country picker */ CountryAttribute | /* Yes / No Toggle */ BooleanAttribute | /* Dropdown select */ SelectAttribute | /* Multi Choice Selection */ MultiSelectAttribute | /* Status select */ StatusAttribute | /* Sequence of unique identifiers */ SequenceAttribute | /* Entity Relationship */ RelationAttribute | /* User Relationship */ UserRelationAttribute | /* Reference to an address attribute of another entity */ AddressRelationAttribute | /* Reference to a payment method attribute of another entity */ PaymentMethodRelationAttribute | /* Currency input */ CurrencyAttribute | /* Repeatable (add N number of fields) */ RepeatableAttribute | /* Tags */ TagsAttribute | /* Numeric input */ NumberAttribute | /* Consent Management */ ConsentAttribute | /* No UI representation */ InternalAttribute | /* Type of attribute to render N number of ordered fields */ OrderedListAttribute | /* File or Image Attachment */ FileAttribute | /* An attribute that is computed from the entity data. For more details on how to use them, check the docs [here](https://e-pilot.atlassian.net/wiki/spaces/EO/pages/5642977476/How+To+Computed+Schema+Attributes) */ ComputedAttribute | /* Partner Status */ PartnerStatusAttribute | /* Email address for send invitation */ InvitationEmailAttribute | /* Automation entity */ AutomationAttribute | /* Epilot internal user info */ InternalUserAttribute | /* Entity Taxonomy */ PurposeAttribute;
@@ -383,7 +383,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "automation";
+            type: "automation";
         }
         export interface BaseAttribute {
             name: string;
@@ -684,7 +684,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "boolean";
+            type: "boolean";
         }
         export type ClassificationId = string; // uuid
         export interface ClassificationsUpdate {
@@ -810,7 +810,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "computed";
+            type: "computed";
         }
         /**
          * Consent Management
@@ -1052,7 +1052,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "country";
+            type: "country";
         }
         /**
          * Currency input
@@ -1302,7 +1302,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "date" | "datetime";
+            type: "date" | "datetime";
         }
         /**
          * example:
@@ -2999,7 +2999,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "internal";
+            type: "internal";
         }
         /**
          * Epilot internal user info
@@ -3119,7 +3119,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "internal_user";
+            type: "internal_user";
         }
         /**
          * Email address for send invitation
@@ -3239,7 +3239,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "invitation_email";
+            type: "invitation_email";
         }
         /**
          * Pass 'true' to generate import template
@@ -3367,7 +3367,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "link";
+            type: "link";
         }
         /**
          * Multi Choice Selection
@@ -3487,7 +3487,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "multiselect" | "checkbox";
+            type: "multiselect" | "checkbox";
             /**
              * controls if the matching of values against the options is case sensitive or not
              */
@@ -3623,7 +3623,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "number";
+            type: "number";
             format?: string;
         }
         /**
@@ -3744,7 +3744,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "ordered_list";
+            type: "ordered_list";
         }
         /**
          * Partner Status
@@ -3864,7 +3864,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "partner_status";
+            type: "partner_status";
         }
         /**
          * Reference to a payment method attribute of another entity
@@ -3984,7 +3984,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "relation_payment_method";
+            type: "relation_payment_method";
             has_primary?: boolean;
         }
         /**
@@ -4113,7 +4113,7 @@ declare namespace Components {
             parents?: ClassificationId /* uuid */[];
             created_at?: string; // date-time
             updated_at?: string; // date-time
-            type?: "purpose";
+            type: "purpose";
         }
         /**
          * example:
@@ -4248,7 +4248,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "relation";
+            type: "relation";
             relation_type?: "has_many" | "has_one";
             /**
              * Map of schema slug to target relation attribute
@@ -4611,7 +4611,7 @@ declare namespace Components {
              * Weak repeatable attributes are kept when duplicating an entity. Strong repeatable attributes are discarded when duplicating an entity.
              */
             relation_affinity_mode?: "weak" | "strong";
-            type?: "string" | "phone" | "email" | "address" | "relation" | "payment" | "price_component" | "date";
+            type: "string" | "phone" | "email" | "address" | "relation" | "payment" | "price_component" | "date";
             /**
              * when enable_relation_picker is set to true the user will be able to pick existing relations as values. Otherwise, the user will need to create new relation to link.
              */
@@ -4890,7 +4890,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "select" | "radio";
+            type: "select" | "radio";
             options?: ({
                 value: string;
                 title?: string;
@@ -5018,7 +5018,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "sequence";
+            type: "sequence";
             /**
              * Prefix added before the sequence number
              * example:
@@ -5145,7 +5145,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "status";
+            type: "status";
             options?: ((string | null) | {
                 /**
                  * The stored value of the option
@@ -5339,7 +5339,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "tags";
+            type: "tags";
             options?: string[];
             suggestions?: string[];
         }
@@ -5500,7 +5500,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "string";
+            type: "string";
             multiline?: boolean;
         }
         /**
@@ -5621,7 +5621,7 @@ declare namespace Components {
                  */
                 hint_tooltip_placement?: string;
             };
-            type?: "relation_user";
+            type: "relation_user";
             multiple?: boolean;
         }
     }

--- a/clients/entity-client/src/openapi.json
+++ b/clients/entity-client/src/openapi.json
@@ -2706,7 +2706,10 @@
               "multiline": {
                 "type": "boolean"
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2725,7 +2728,10 @@
                   "link"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2744,7 +2750,10 @@
                   "internal"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2763,7 +2772,10 @@
                   "boolean"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2783,7 +2795,10 @@
                   "datetime"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2802,7 +2817,10 @@
                   "country"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2851,7 +2869,10 @@
                 "type": "boolean",
                 "description": "Allow arbitrary input values in addition to provided options"
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2910,7 +2931,10 @@
                 "type": "boolean",
                 "description": "Allow arbitrary input values in addition to provided options"
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2961,7 +2985,10 @@
                   ]
                 }
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -2989,7 +3016,10 @@
                 "type": "integer",
                 "minimum": 0
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3118,7 +3148,10 @@
             "type": "string",
             "description": "An hint on how to display the summary field"
           }
-        }
+        },
+        "required": [
+          "type"
+        ]
       },
       "RelationAttribute": {
         "allOf": [
@@ -3283,7 +3316,10 @@
                 "type": "string",
                 "description": "Optional placeholder text for the relation search input. The translated value for search_placeholder is used, if found else the string is used as is."
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3306,7 +3342,10 @@
                 "type": "boolean",
                 "default": false
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3328,7 +3367,10 @@
               "has_primary": {
                 "type": "boolean"
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3350,7 +3392,10 @@
               "has_primary": {
                 "type": "boolean"
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3369,7 +3414,10 @@
                   "invitation_email"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3388,7 +3436,10 @@
                   "automation"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3407,7 +3458,10 @@
                   "internal_user"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3429,7 +3483,10 @@
                   "purpose"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3474,7 +3531,10 @@
                 "default": true,
                 "description": "when enable_relation_picker is set to true the user will be able to pick existing relations as values. Otherwise, the user will need to create new relation to link."
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3505,7 +3565,10 @@
                   "type": "string"
                 }
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3527,7 +3590,10 @@
               "format": {
                 "type": "string"
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3578,7 +3644,10 @@
                   "ordered_list"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3597,7 +3666,10 @@
                   "computed"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3616,7 +3688,10 @@
                   "partner_status"
                 ]
               }
-            }
+            },
+            "required": [
+              "type"
+            ]
           }
         ]
       },
@@ -3654,6 +3729,7 @@
           }
         },
         "required": [
+          "type",
           "label",
           "value"
         ]


### PR DESCRIPTION
It would be very helpful if we could have attribute `type`s as required, that would allow us to discriminate an attribute by its type, and avoid a lot of of the assertions around attributes in entity-ui.

Do you foresee any undesired consequences at the API level that could arise from this change?