### PR TITLE
include extra definitions

### DIFF
--- a/clients/entity-mapping-client/package.json
+++ b/clients/entity-mapping-client/package.json
@@ -25,7 +25,7 @@
     "test": "jest",
     "typescript": "tsc",
     "bundle-definition": "webpack",
-    "openapi": "node ../../scripts/update-openapi.js https://docs.api.epilot.io/entity-mapping-api.yaml",
+    "openapi": "node ../../scripts/update-openapi.js https://docs.api.epilot.io/entity-mapping-api.yaml '' --include-ext",
     "typegen": "echo '/* eslint-disable */' > src/openapi.d.ts && typegen ./src/openapi.json >> src/openapi.d.ts",
     "build": "tsc && npm run bundle-definition",
     "build:watch": "npm run build && tsc -w",

--- a/clients/entity-mapping-client/src/openapi-runtime.json
+++ b/clients/entity-mapping-client/src/openapi-runtime.json
@@ -178,5 +178,10 @@
       }
     }
   },
-  "components": {}
+  "components": {},
+  "servers": [
+    {
+      "url": "https://entity-mapping.sls.epilot.io"
+    }
+  ]
 }

--- a/clients/entity-mapping-client/src/openapi.json
+++ b/clients/entity-mapping-client/src/openapi.json
@@ -1602,5 +1602,13 @@
         ]
       }
     }
-  }
+  },
+  "servers": [
+    {
+      "url": "https://entity-mapping.sls.epilot.io"
+    },
+    {
+      "url": "https://entity-mapping.sls.epilot.io"
+    }
+  ]
 }

--- a/scripts/update-openapi.js
+++ b/scripts/update-openapi.js
@@ -10,7 +10,7 @@ const { execSync } = require('child_process');
 
 const defaultSrc = process.argv[2];
 const overrideSrc = process.argv[3];
-const includeEXT = process.argv.includes('--include-ext')
+const includeEXT = process.argv.includes('--include-ext');
 const sourceFile = overrideSrc || defaultSrc;
 
 const OPENAPICMD = 'npx openapicmd';

--- a/scripts/update-openapi.js
+++ b/scripts/update-openapi.js
@@ -10,6 +10,7 @@ const { execSync } = require('child_process');
 
 const defaultSrc = process.argv[2];
 const overrideSrc = process.argv[3];
+const includeEXT = process.argv.includes('--include-ext')
 const sourceFile = overrideSrc || defaultSrc;
 
 const OPENAPICMD = 'npx openapicmd';
@@ -28,7 +29,7 @@ execSync(
   [
     OPENAPICMD,
     'read',
-    '--exclude-ext x-internal',
+    includeEXT ? '' : '--exclude-ext x-internal',
     `--json ${sourceFile}`,
     serverURL ? `--server ${serverURL}` : '',
     '>',


### PR DESCRIPTION
In the cases when there are types in openapi schema that are not in use. The option `--exclude-ext x-internal` used in the `update-openapi.js` is removing them.

In the case of entity mapping api client, we have cases that this API client dictated the content of other APIs. so we would like to include it.

The PR is allowing the option `--include-ext` to be passed to the script to make include the extra types.