### PR TITLE
Update `file-client` adding support to `index_tag`

### DIFF
--- a/clients/file-client/package.json
+++ b/clients/file-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/file-client",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Client library for the epilot File API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/file-client/src/openapi.d.ts
+++ b/clients/file-client/src/openapi.d.ts
@@ -287,6 +287,12 @@ declare namespace Components {
              */
             mime_type?: string;
             /**
+             * Used to index the file at the storage layer, which helps when browsing for this file
+             * example:
+             * 2f6a377c8e78
+             */
+            index_tag?: string;
+            /**
              * Allows passing in custom metadata for the file, expects key-value pairs of string type
              * example:
              * {

--- a/clients/file-client/src/openapi.json
+++ b/clients/file-client/src/openapi.json
@@ -1071,6 +1071,12 @@
             "example": "application/pdf",
             "default": "application/octet-stream"
           },
+          "index_tag": {
+            "type": "string",
+            "example": "2f6a377c8e78",
+            "maxLength": 64,
+            "description": "Used to index the file at the storage layer, which helps when browsing for this file"
+          },
           "metadata": {
             "type": "object",
             "additionalProperties": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@epilot/sdk-monorepo",
   "private": true,
-  "version": "4.6.1",
+  "version": "4.7.0",
   "description": "Javascript SDK monorepo for epilot",
   "scripts": {
     "clean": "lerna clean",


### PR DESCRIPTION
Allows indexing uploaded files by the given "index tag", which makes them more easily searchable at rest.