### PR TITLE
Feat: Added purge query param to delete file API

### DIFF
--- a/clients/file-client/package.json
+++ b/clients/file-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/file-client",
-  "version": "1.14.0-rc1",
+  "version": "1.14.0-rc2",
   "description": "Client library for the epilot File API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -47,7 +47,7 @@
     "!*.config.js"
   ],
   "peerDependencies": {
-    "axios": "^1.6.2"
+    "axios": "^1.8.1"
   },
   "dependencies": {
     "buffer": "^6.0.3",
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "axios": "^1.6.2",
+    "axios": "^1.8.1",
     "copy-webpack-plugin": "^7.0.0",
     "jest": "^26.6.3",
     "json-loader": "^0.5.7",

--- a/clients/file-client/package.json
+++ b/clients/file-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/file-client",
-  "version": "1.13.1",
+  "version": "1.14.0-rc1",
   "description": "Client library for the epilot File API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/file-client/package.json
+++ b/clients/file-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/file-client",
-  "version": "1.14.0-rc2",
+  "version": "1.14.0",
   "description": "Client library for the epilot File API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/file-client/src/openapi-runtime.json
+++ b/clients/file-client/src/openapi-runtime.json
@@ -5,19 +5,9 @@
     "version": ""
   },
   "paths": {
-    "/v1/files/public/upload": {
+    "/v2/files/upload": {
       "post": {
-        "operationId": "uploadFilePublic",
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        }
-      }
-    },
-    "/v1/files/upload": {
-      "post": {
-        "operationId": "uploadFile",
+        "operationId": "uploadFileV2",
         "parameters": [
           {
             "name": "file_entity_id",
@@ -28,17 +18,115 @@
           "content": {
             "application/json": {}
           }
-        }
+        },
+        "responses": {}
+      }
+    },
+    "/v2/files": {
+      "post": {
+        "operationId": "saveFileV2",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ActivityIdQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/FillActivityQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/StrictQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/AsyncOperationQueryParam"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      }
+    },
+    "/v1/files/upload": {
+      "post": {
+        "operationId": "uploadFile",
+        "deprecated": true,
+        "parameters": [
+          {
+            "name": "file_entity_id",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
       }
     },
     "/v1/files": {
       "post": {
         "operationId": "saveFile",
+        "deprecated": true,
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ActivityIdQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/AsyncOperationQueryParam"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {}
           }
-        }
+        },
+        "responses": {}
+      }
+    },
+    "/v2/files/{id}": {
+      "get": {
+        "operationId": "getFile",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "source_url",
+            "in": "query"
+          },
+          {
+            "$ref": "#/components/parameters/StrictQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/AsyncOperationQueryParam"
+          }
+        ],
+        "responses": {}
+      },
+      "delete": {
+        "operationId": "deleteFile",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "name": "purge",
+            "in": "query"
+          },
+          {
+            "$ref": "#/components/parameters/ActivityIdQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/StrictQueryParam"
+          }
+        ],
+        "responses": {}
       }
     },
     "/v1/files/{id}/download": {
@@ -58,27 +146,8 @@
             "name": "attachment",
             "in": "query"
           }
-        ]
-      }
-    },
-    "/v1/files/download:verify": {
-      "post": {
-        "operationId": "verifyCustomDownloadUrl",
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        }
-      }
-    },
-    "/v1/files:downloadFiles": {
-      "post": {
-        "operationId": "downloadFiles",
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        }
+        ],
+        "responses": {}
       }
     },
     "/v1/files:downloadS3": {
@@ -99,7 +168,19 @@
             "name": "attachment",
             "in": "query"
           }
-        ]
+        ],
+        "responses": {}
+      }
+    },
+    "/v1/files:downloadFiles": {
+      "post": {
+        "operationId": "downloadFiles",
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
       }
     },
     "/v1/files/{id}/preview": {
@@ -123,7 +204,53 @@
             "name": "h",
             "in": "query"
           }
-        ]
+        ],
+        "responses": {}
+      }
+    },
+    "/v1/files:previewS3": {
+      "post": {
+        "operationId": "previewS3File",
+        "parameters": [
+          {
+            "name": "w",
+            "in": "query"
+          },
+          {
+            "name": "h",
+            "in": "query"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      },
+      "get": {
+        "operationId": "previewS3FileGet",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true
+          },
+          {
+            "name": "bucket",
+            "in": "query",
+            "required": true
+          },
+          {
+            "name": "w",
+            "in": "query"
+          },
+          {
+            "name": "h",
+            "in": "query"
+          }
+        ],
+        "responses": {}
       }
     },
     "/v1/files/public/{id}/preview": {
@@ -151,68 +278,18 @@
             "name": "org_id",
             "in": "query"
           }
-        ]
-      }
-    },
-    "/v1/files:previewS3": {
-      "get": {
-        "operationId": "previewS3FileGet",
-        "parameters": [
-          {
-            "name": "key",
-            "in": "query",
-            "required": true
-          },
-          {
-            "name": "bucket",
-            "in": "query",
-            "required": true
-          },
-          {
-            "name": "w",
-            "in": "query"
-          },
-          {
-            "name": "h",
-            "in": "query"
-          }
-        ]
-      },
-      "post": {
-        "operationId": "previewS3File",
-        "parameters": [
-          {
-            "name": "w",
-            "in": "query"
-          },
-          {
-            "name": "h",
-            "in": "query"
-          }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        }
-      }
-    },
-    "/v1/files/delete": {
-      "delete": {
-        "operationId": "deleteFile",
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        }
+        "responses": {}
       }
     },
     "/v1/files/session": {
       "get": {
-        "operationId": "getSession"
+        "operationId": "getSession",
+        "responses": {}
       },
       "delete": {
-        "operationId": "deleteSession"
+        "operationId": "deleteSession",
+        "responses": {}
       }
     },
     "/v1/files/{id}/public/links": {
@@ -224,17 +301,19 @@
             "in": "path",
             "required": true
           }
-        ]
+        ],
+        "responses": {}
       },
       "get": {
-        "operationId": "getAllPublicLinksForFile",
+        "operationId": "listPublicLinksForFile",
         "parameters": [
           {
             "name": "id",
             "in": "path",
             "required": true
           }
-        ]
+        ],
+        "responses": {}
       }
     },
     "/v1/files/public/links/{id}/{filename}": {
@@ -250,8 +329,14 @@
             "name": "filename",
             "in": "path",
             "required": true
+          },
+          {
+            "name": "hash",
+            "in": "query",
+            "required": false
           }
-        ]
+        ],
+        "responses": {}
       }
     },
     "/v1/files/public/links/{id}": {
@@ -263,37 +348,57 @@
             "in": "path",
             "required": true
           }
-        ]
-      }
-    },
-    "/v2/files/upload": {
-      "post": {
-        "operationId": "uploadFileV2",
-        "parameters": [
-          {
-            "name": "file_entity_id",
-            "in": "query"
-          }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {}
-          }
-        }
+        "responses": {}
       }
     },
-    "/v2/files": {
+    "/v1/files/download:verify": {
       "post": {
-        "operationId": "saveFileV2",
+        "operationId": "verifyCustomDownloadUrl",
         "requestBody": {
           "content": {
             "application/json": {}
           }
-        }
+        },
+        "responses": {}
+      }
+    },
+    "/v1/files/public/upload": {
+      "post": {
+        "operationId": "uploadFilePublic",
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
       }
     }
   },
-  "components": {},
+  "components": {
+    "parameters": {
+      "StrictQueryParam": {
+        "name": "strict",
+        "in": "query",
+        "required": false
+      },
+      "ActivityIdQueryParam": {
+        "name": "activity_id",
+        "in": "query",
+        "required": false
+      },
+      "FillActivityQueryParam": {
+        "name": "fill_activity",
+        "in": "query",
+        "required": false
+      },
+      "AsyncOperationQueryParam": {
+        "name": "async",
+        "in": "query",
+        "required": false
+      }
+    }
+  },
   "servers": [
     {
       "url": "https://file.sls.epilot.io"

--- a/clients/file-client/src/openapi.d.ts
+++ b/clients/file-client/src/openapi.d.ts
@@ -9,29 +9,79 @@ import type {
 } from 'openapi-client-axios';
 
 declare namespace Components {
+    namespace Parameters {
+        export type ActivityIdQueryParam = /**
+         * See https://github.com/ulid/spec
+         * example:
+         * 01F130Q52Q6MWSNS8N2AVXV4JN
+         */
+        Schemas.ActivityId /* ulid */;
+        export type AsyncOperationQueryParam = boolean;
+        export type FillActivityQueryParam = boolean;
+        export type StrictQueryParam = boolean;
+    }
+    export interface QueryParameters {
+        StrictQueryParam?: Parameters.StrictQueryParam;
+        ActivityIdQueryParam?: Parameters.ActivityIdQueryParam;
+        FillActivityQueryParam?: Parameters.FillActivityQueryParam;
+        AsyncOperationQueryParam?: Parameters.AsyncOperationQueryParam;
+    }
     namespace Schemas {
+        /**
+         * See https://github.com/ulid/spec
+         * example:
+         * 01F130Q52Q6MWSNS8N2AVXV4JN
+         */
+        export type ActivityId = string; // ulid
+        /**
+         * Access control list (ACL) for an entity. Defines sharing access to external orgs or users.
+         */
+        export interface BaseEntityAcl {
+            view?: string[];
+            edit?: string[];
+            delete?: string[];
+        }
+        /**
+         * The user / organization owning this entity.
+         *
+         * Note: Owner implicitly has access to the entity regardless of ACLs.
+         *
+         */
+        export interface BaseEntityOwner {
+            /**
+             * example:
+             * 123
+             */
+            org_id: string;
+            /**
+             * example:
+             * 123
+             */
+            user_id?: string;
+        }
         export interface CommonSaveFilePayload {
             [name: string]: any;
             /**
              * if passed, adds a new version to existing file entity
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            _id?: string;
+            /**
+             * Deprecated, use _id instead
              */
             file_entity_id?: string;
-            document_type?: "document" | "document_template" | "text" | "image" | "video" | "audio" | "spreadsheet" | "presentation" | "font" | "archive" | "application" | "unknown";
-            /**
-             * example:
-             * document.pdf
-             */
-            filename?: string;
-            _tags?: string[];
-            access_control?: "private" | "public-read";
             /**
              * List of entities to relate the file to
              */
             relations?: FileRelationItem[];
         }
-        export interface DeleteFilePayload {
-            s3ref: S3Reference;
-        }
+        /**
+         * Custom external download url used for the file
+         * example:
+         * https://some-api-url.com/download?file_id=123
+         */
+        export type CustomDownloadUrl = string; // uri
         export type DownloadFilesPayload = {
             id: /**
              * example:
@@ -56,28 +106,33 @@ declare namespace Components {
          * contact
          */
         export type EntitySlug = string;
-        export interface FileEntity {
-            _id?: /**
+        export interface FileAttributes {
+            /**
              * example:
-             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             * [
+             *   "tag1",
+             *   "tag2"
+             * ]
              */
-            FileEntityId;
+            _tags?: string[];
+            /**
+             * example:
+             * [
+             *   "8d396871-95a0-4c9d-bb4d-9eda9c35776c",
+             *   "da7cdf9a-01be-40c9-a29c-9a8f9f0de6f8"
+             * ]
+             */
+            _purpose?: string[];
+            /**
+             * Manifest ID used to create/update the entity
+             */
+            _manifest?: string /* uuid */[];
             /**
              * example:
              * document.pdf
              */
             filename?: string;
-            access_control?: "private" | "public-read";
-            /**
-             * Direct URL for file (public only if file access control is public-read)
-             * example:
-             * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
-             */
-            public_url?: string; // url
-            /**
-             * Human readable type for file
-             */
-            type?: "document" | "document_template" | "text" | "image" | "video" | "audio" | "spreadsheet" | "presentation" | "font" | "archive" | "application" | "unknown";
+            type?: FileType;
             /**
              * MIME type of the file
              * example:
@@ -86,11 +141,128 @@ declare namespace Components {
             mime_type?: string;
             /**
              * File size in bytes
+             * example:
+             * 1234
              */
             size_bytes?: number;
-            versions?: {
-                s3ref?: S3Reference;
-            }[];
+            /**
+             * Human readable file size
+             * example:
+             * 1.2 MB
+             */
+            readable_size?: string;
+            access_control?: "private" | "public-read";
+            /**
+             * Direct URL for file (public only if file access control is public-read)
+             * example:
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
+             */
+            public_url?: string; // url
+            custom_download_url?: /**
+             * Custom external download url used for the file
+             * example:
+             * https://some-api-url.com/download?file_id=123
+             */
+            CustomDownloadUrl /* uri */;
+        }
+        export interface FileEntity {
+            /**
+             * example:
+             * document.pdf
+             */
+            _title: string;
+            _schema: "file";
+            /**
+             * example:
+             * 123
+             */
+            _org: string;
+            _id: /**
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            FileEntityId;
+            /**
+             * example:
+             * [
+             *   "tag1",
+             *   "tag2"
+             * ]
+             */
+            _tags?: string[];
+            /**
+             * example:
+             * [
+             *   "8d396871-95a0-4c9d-bb4d-9eda9c35776c",
+             *   "da7cdf9a-01be-40c9-a29c-9a8f9f0de6f8"
+             * ]
+             */
+            _purpose?: string[];
+            /**
+             * Manifest ID used to create/update the entity
+             */
+            _manifest?: string /* uuid */[];
+            /**
+             * example:
+             * document.pdf
+             */
+            filename: string;
+            type: FileType;
+            /**
+             * MIME type of the file
+             * example:
+             * application/pdf
+             */
+            mime_type?: string;
+            /**
+             * File size in bytes
+             * example:
+             * 1234
+             */
+            size_bytes?: number;
+            /**
+             * Human readable file size
+             * example:
+             * 1.2 MB
+             */
+            readable_size?: string;
+            access_control: "private" | "public-read";
+            /**
+             * Direct URL for file (public only if file access control is public-read)
+             * example:
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
+             */
+            public_url?: string; // url
+            custom_download_url?: /**
+             * Custom external download url used for the file
+             * example:
+             * https://some-api-url.com/download?file_id=123
+             */
+            CustomDownloadUrl /* uri */;
+            /**
+             * Source URL for the file. Included if the entity was created from source_url, or when ?source_url=true
+             * example:
+             * https://productengineer-content.s3.eu-west-1.amazonaws.com/product-engineer-checklist.pdf
+             */
+            source_url?: string;
+            s3ref?: S3Ref;
+            versions: FileItem[];
+            _updated_at?: string; // date-time
+            _created_at?: string; // date-time
+            _acl?: /* Access control list (ACL) for an entity. Defines sharing access to external orgs or users. */ BaseEntityAcl;
+            _owners?: /**
+             * The user / organization owning this entity.
+             *
+             * Note: Owner implicitly has access to the entity regardless of ACLs.
+             *
+             */
+            BaseEntityOwner[];
+            /**
+             * Additional fields that are not part of the schema
+             */
+            __additional?: {
+                [name: string]: any;
+            } | null;
         }
         /**
          * example:
@@ -98,16 +270,7 @@ declare namespace Components {
          */
         export type FileEntityId = string;
         export interface FileItem {
-            /**
-             * example:
-             * epilot-files-prod
-             */
-            bucket: string;
-            /**
-             * example:
-             * 123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
-             */
-            key: string;
+            s3ref?: S3Ref;
             /**
              * example:
              * document.pdf
@@ -118,6 +281,11 @@ declare namespace Components {
              * 1234
              */
             size_bytes?: number;
+            /**
+             * example:
+             * 1.2 MB
+             */
+            readable_size?: string;
             /**
              * example:
              * image/jpeg
@@ -138,35 +306,18 @@ declare namespace Components {
             EntitySlug;
             _tags?: string[];
         }
+        export type FileType = "document" | "document_template" | "text" | "image" | "video" | "audio" | "spreadsheet" | "presentation" | "font" | "archive" | "application" | "unknown";
         export interface FileUpload {
+            s3ref?: S3Reference;
             /**
              * example:
-             * {
-             *   "bucket": "epilot-files-prod",
-             *   "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
-             * }
-             */
-            s3ref?: {
-                /**
-                 * example:
-                 * epilot-files-prod
-                 */
-                bucket: string;
-                /**
-                 * example:
-                 * 123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
-                 */
-                key: string;
-            };
-            /**
-             * example:
-             * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
              */
             upload_url?: string; // url
             /**
              * Returned only if file is permanent i.e. file_entity_id is passed
              * example:
-             * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
              */
             public_url?: string; // url
         }
@@ -188,10 +339,11 @@ declare namespace Components {
              */
             last_accessed_at?: string;
         }
+        export type S3Ref = S3Reference;
         export interface S3Reference {
             /**
              * example:
-             * epilot-files-prod
+             * epilot-prod-user-content
              */
             bucket: string;
             /**
@@ -204,76 +356,232 @@ declare namespace Components {
             [name: string]: any;
             /**
              * if passed, adds a new version to existing file entity
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            _id?: string;
+            /**
+             * Deprecated, use _id instead
              */
             file_entity_id?: string;
-            document_type?: "document" | "document_template" | "text" | "image" | "video" | "audio" | "spreadsheet" | "presentation" | "font" | "archive" | "application" | "unknown";
-            /**
-             * example:
-             * document.pdf
-             */
-            filename?: string;
-            _tags?: string[];
-            access_control?: "private" | "public-read";
             /**
              * List of entities to relate the file to
              */
             relations?: FileRelationItem[];
             /**
-             * Custom external download url used for the file
+             * example:
+             * [
+             *   "tag1",
+             *   "tag2"
+             * ]
              */
-            custom_download_url: string; // uri
-        }
-        export type SaveFilePayload = SaveS3FilePayload | SaveCustomFilePayload;
-        export interface SaveFilePayloadV2 {
-            [name: string]: any;
-            s3ref: {
-                /**
-                 * example:
-                 * epilot-files-prod
-                 */
-                bucket: string;
-                /**
-                 * example:
-                 * 123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
-                 */
-                key: string;
-            };
+            _tags?: string[];
+            /**
+             * example:
+             * [
+             *   "8d396871-95a0-4c9d-bb4d-9eda9c35776c",
+             *   "da7cdf9a-01be-40c9-a29c-9a8f9f0de6f8"
+             * ]
+             */
+            _purpose?: string[];
+            /**
+             * Manifest ID used to create/update the entity
+             */
+            _manifest?: string /* uuid */[];
             /**
              * example:
              * document.pdf
              */
-            filename: string;
+            filename?: string;
+            type?: FileType;
             /**
-             * if passed, adds a new version to existing file entity
+             * MIME type of the file
+             * example:
+             * application/pdf
              */
-            file_entity_id?: string;
-            document_type?: "document" | "document_template" | "text" | "image" | "video" | "audio" | "spreadsheet" | "presentation" | "font" | "archive" | "application" | "unknown";
-            _tags?: string[];
+            mime_type?: string;
+            /**
+             * File size in bytes
+             * example:
+             * 1234
+             */
+            size_bytes?: number;
+            /**
+             * Human readable file size
+             * example:
+             * 1.2 MB
+             */
+            readable_size?: string;
             access_control?: "private" | "public-read";
             /**
-             * Custom external download url used for the file
+             * Direct URL for file (public only if file access control is public-read)
+             * example:
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
              */
-            custom_download_url?: string; // uri
+            public_url?: string; // url
+            custom_download_url?: /**
+             * Custom external download url used for the file
+             * example:
+             * https://some-api-url.com/download?file_id=123
+             */
+            CustomDownloadUrl /* uri */;
         }
+        export interface SaveFileFromSourceURLPayload {
+            [name: string]: any;
+            /**
+             * if passed, adds a new version to existing file entity
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            _id?: string;
+            /**
+             * Deprecated, use _id instead
+             */
+            file_entity_id?: string;
+            /**
+             * List of entities to relate the file to
+             */
+            relations?: FileRelationItem[];
+            /**
+             * example:
+             * [
+             *   "tag1",
+             *   "tag2"
+             * ]
+             */
+            _tags?: string[];
+            /**
+             * example:
+             * [
+             *   "8d396871-95a0-4c9d-bb4d-9eda9c35776c",
+             *   "da7cdf9a-01be-40c9-a29c-9a8f9f0de6f8"
+             * ]
+             */
+            _purpose?: string[];
+            /**
+             * Manifest ID used to create/update the entity
+             */
+            _manifest?: string /* uuid */[];
+            /**
+             * example:
+             * document.pdf
+             */
+            filename?: string;
+            type?: FileType;
+            /**
+             * MIME type of the file
+             * example:
+             * application/pdf
+             */
+            mime_type?: string;
+            /**
+             * File size in bytes
+             * example:
+             * 1234
+             */
+            size_bytes?: number;
+            /**
+             * Human readable file size
+             * example:
+             * 1.2 MB
+             */
+            readable_size?: string;
+            access_control?: "private" | "public-read";
+            /**
+             * Direct URL for file (public only if file access control is public-read)
+             * example:
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
+             */
+            public_url?: string; // url
+            custom_download_url?: /**
+             * Custom external download url used for the file
+             * example:
+             * https://some-api-url.com/download?file_id=123
+             */
+            CustomDownloadUrl /* uri */;
+            source_url?: /**
+             * Custom external download url used for the file
+             * example:
+             * https://some-api-url.com/download?file_id=123
+             */
+            CustomDownloadUrl /* uri */;
+        }
+        export type SaveFilePayload = SaveS3FilePayload | SaveFileFromSourceURLPayload | SaveCustomFilePayload;
+        export type SaveFilePayloadV2 = SaveS3FilePayload | SaveFileFromSourceURLPayload | SaveCustomFilePayload;
         export interface SaveS3FilePayload {
             [name: string]: any;
             /**
              * if passed, adds a new version to existing file entity
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            _id?: string;
+            /**
+             * Deprecated, use _id instead
              */
             file_entity_id?: string;
-            document_type?: "document" | "document_template" | "text" | "image" | "video" | "audio" | "spreadsheet" | "presentation" | "font" | "archive" | "application" | "unknown";
+            /**
+             * List of entities to relate the file to
+             */
+            relations?: FileRelationItem[];
+            /**
+             * example:
+             * [
+             *   "tag1",
+             *   "tag2"
+             * ]
+             */
+            _tags?: string[];
+            /**
+             * example:
+             * [
+             *   "8d396871-95a0-4c9d-bb4d-9eda9c35776c",
+             *   "da7cdf9a-01be-40c9-a29c-9a8f9f0de6f8"
+             * ]
+             */
+            _purpose?: string[];
+            /**
+             * Manifest ID used to create/update the entity
+             */
+            _manifest?: string /* uuid */[];
             /**
              * example:
              * document.pdf
              */
             filename?: string;
-            _tags?: string[];
+            type?: FileType;
+            /**
+             * MIME type of the file
+             * example:
+             * application/pdf
+             */
+            mime_type?: string;
+            /**
+             * File size in bytes
+             * example:
+             * 1234
+             */
+            size_bytes?: number;
+            /**
+             * Human readable file size
+             * example:
+             * 1.2 MB
+             */
+            readable_size?: string;
             access_control?: "private" | "public-read";
             /**
-             * List of entities to relate the file to
+             * Direct URL for file (public only if file access control is public-read)
+             * example:
+             * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
              */
-            relations?: FileRelationItem[];
-            s3ref: S3Reference;
+            public_url?: string; // url
+            custom_download_url?: /**
+             * Custom external download url used for the file
+             * example:
+             * https://some-api-url.com/download?file_id=123
+             */
+            CustomDownloadUrl /* uri */;
+            s3ref?: S3Ref;
         }
         export interface UploadFilePayload {
             /**
@@ -310,7 +618,7 @@ declare namespace Components {
              * example:
              * https://some-api-url.com?file_id=123&expires_at=1699273500029&signature=abcdefg
              */
-            custom_download_url: string; // uri
+            custom_download_url: string;
         }
     }
 }
@@ -323,6 +631,10 @@ declare namespace Paths {
              * invoice-2023-12.pdf
              */
             export type Filename = string;
+            /**
+             * An optional cache-busting hash for the file
+             */
+            export type Hash = string;
             /**
              * Id of the publicly generated link
              * example:
@@ -344,16 +656,40 @@ declare namespace Paths {
              */
             Parameters.Filename;
         }
+        export interface QueryParameters {
+            hash?: /* An optional cache-busting hash for the file */ Parameters.Hash;
+        }
         namespace Responses {
             export interface $302 {
             }
         }
     }
     namespace DeleteFile {
-        export type RequestBody = Components.Schemas.DeleteFilePayload;
+        namespace Parameters {
+            export type ActivityId = /**
+             * See https://github.com/ulid/spec
+             * example:
+             * 01F130Q52Q6MWSNS8N2AVXV4JN
+             */
+            Components.Schemas.ActivityId /* ulid */;
+            export type Id = /**
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            Components.Schemas.FileEntityId;
+            export type Purge = boolean;
+            export type Strict = boolean;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export interface QueryParameters {
+            purge?: Parameters.Purge;
+            activity_id?: Parameters.ActivityId;
+            strict?: Parameters.Strict;
+        }
         namespace Responses {
-            export interface $200 {
-            }
+            export type $200 = Components.Schemas.FileEntity;
         }
     }
     namespace DeleteSession {
@@ -383,7 +719,7 @@ declare namespace Paths {
             export interface $200 {
                 /**
                  * example:
-                 * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
+                 * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
                  */
                 download_url?: string; // uri
             }
@@ -395,7 +731,7 @@ declare namespace Paths {
             export type $200 = {
                 /**
                  * example:
-                 * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
+                 * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
                  */
                 download_url?: string; // uri
                 file_entity_id?: string; // uuid
@@ -417,7 +753,7 @@ declare namespace Paths {
             export interface $200 {
                 /**
                  * example:
-                 * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
+                 * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
                  */
                 download_url?: string; // uri
             }
@@ -442,7 +778,39 @@ declare namespace Paths {
             export type $201 = string;
         }
     }
-    namespace GetAllPublicLinksForFile {
+    namespace GetFile {
+        namespace Parameters {
+            export type Async = boolean;
+            export type Id = /**
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            Components.Schemas.FileEntityId;
+            /**
+             * Generate a source_url for the file entity, if it doesn't have one
+             */
+            export type SourceUrl = boolean;
+            export type Strict = boolean;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export interface QueryParameters {
+            source_url?: /* Generate a source_url for the file entity, if it doesn't have one */ Parameters.SourceUrl;
+            strict?: Parameters.Strict;
+            async?: Parameters.Async;
+        }
+        namespace Responses {
+            export type $200 = Components.Schemas.FileEntity;
+        }
+    }
+    namespace GetSession {
+        namespace Responses {
+            export interface $200 {
+            }
+        }
+    }
+    namespace ListPublicLinksForFile {
         namespace Parameters {
             /**
              * ID of the file entity
@@ -462,12 +830,6 @@ declare namespace Paths {
         namespace Responses {
             export interface $200 {
                 results?: Components.Schemas.PublicLink[];
-            }
-        }
-    }
-    namespace GetSession {
-        namespace Responses {
-            export interface $200 {
             }
         }
     }
@@ -522,7 +884,7 @@ declare namespace Paths {
             w?: Parameters.W;
             h?: Parameters.H;
         }
-        export type RequestBody = Components.Schemas.S3Reference;
+        export type RequestBody = Components.Schemas.S3Ref;
     }
     namespace PreviewS3FileGet {
         namespace Parameters {
@@ -564,15 +926,45 @@ declare namespace Paths {
         }
     }
     namespace SaveFile {
+        namespace Parameters {
+            export type ActivityId = /**
+             * See https://github.com/ulid/spec
+             * example:
+             * 01F130Q52Q6MWSNS8N2AVXV4JN
+             */
+            Components.Schemas.ActivityId /* ulid */;
+            export type Async = boolean;
+        }
+        export interface QueryParameters {
+            activity_id?: Parameters.ActivityId;
+            async?: Parameters.Async;
+        }
         export type RequestBody = Components.Schemas.SaveFilePayload;
         namespace Responses {
             export type $201 = Components.Schemas.FileEntity;
         }
     }
     namespace SaveFileV2 {
+        namespace Parameters {
+            export type ActivityId = /**
+             * See https://github.com/ulid/spec
+             * example:
+             * 01F130Q52Q6MWSNS8N2AVXV4JN
+             */
+            Components.Schemas.ActivityId /* ulid */;
+            export type Async = boolean;
+            export type FillActivity = boolean;
+            export type Strict = boolean;
+        }
+        export interface QueryParameters {
+            activity_id?: Parameters.ActivityId;
+            fill_activity?: Parameters.FillActivity;
+            strict?: Parameters.Strict;
+            async?: Parameters.Async;
+        }
         export type RequestBody = Components.Schemas.SaveFilePayloadV2;
         namespace Responses {
-            export type $201 = Components.Schemas.FileEntity;
+            export type $200 = Components.Schemas.FileEntity;
         }
     }
     namespace UploadFile {
@@ -589,34 +981,16 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.UploadFilePayload;
         namespace Responses {
             export interface $201 {
+                s3ref?: Components.Schemas.S3Reference;
                 /**
                  * example:
-                 * {
-                 *   "bucket": "epilot-files-prod",
-                 *   "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
-                 * }
-                 */
-                s3ref?: {
-                    /**
-                     * example:
-                     * epilot-files-prod
-                     */
-                    bucket: string;
-                    /**
-                     * example:
-                     * 123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
-                     */
-                    key: string;
-                };
-                /**
-                 * example:
-                 * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
+                 * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
                  */
                 upload_url?: string; // url
                 /**
                  * Returned only if file is permanent i.e. file_entity_id is passed
                  * example:
-                 * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
+                 * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
                  */
                 public_url?: string; // url
             }
@@ -626,28 +1000,10 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.UploadFilePayload;
         namespace Responses {
             export interface $201 {
+                s3ref?: Components.Schemas.S3Reference;
                 /**
                  * example:
-                 * {
-                 *   "bucket": "epilot-files-prod",
-                 *   "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
-                 * }
-                 */
-                s3ref?: {
-                    /**
-                     * example:
-                     * epilot-files-prod
-                     */
-                    bucket: string;
-                    /**
-                     * example:
-                     * 123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf
-                     */
-                    key: string;
-                };
-                /**
-                 * example:
-                 * https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
+                 * https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123
                  */
                 upload_url?: string; // url
             }
@@ -679,26 +1035,40 @@ declare namespace Paths {
     }
 }
 
+
 export interface OperationMethods {
   /**
-   * uploadFilePublic - uploadFilePublic
+   * uploadFileV2 - uploadFileV2
    * 
    * Create pre-signed S3 URL to upload a file to keep temporarily (one week).
    * 
-   * Use the createFile operation to store file file permanently.
+   * Use the saveFileV2 operation to store file file permanently.
    * 
    */
-  'uploadFilePublic'(
-    parameters?: Parameters<UnknownParamsObject> | null,
-    data?: Paths.UploadFilePublic.RequestBody,
+  'uploadFileV2'(
+    parameters?: Parameters<Paths.UploadFileV2.QueryParameters> | null,
+    data?: Paths.UploadFileV2.RequestBody,
     config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.UploadFilePublic.Responses.$201>
+  ): OperationResponse<Paths.UploadFileV2.Responses.$201>
+  /**
+   * saveFileV2 - saveFileV2
+   * 
+   * Saves a permanent file entity. Updates an existing file entity when `_id` is passed.
+   * 
+   * Saves metadata to file entity and stores a version when `s3ref` or `source_url` is passed.
+   * 
+   */
+  'saveFileV2'(
+    parameters?: Parameters<Paths.SaveFileV2.QueryParameters> | null,
+    data?: Paths.SaveFileV2.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.SaveFileV2.Responses.$200>
   /**
    * uploadFile - uploadFile
    * 
    * Create pre-signed S3 URL to upload a file to keep temporarily (one week).
    * 
-   * Use the createFile operation to store file file permanently.
+   * Use the saveFile operation to store file file permanently.
    * 
    */
   'uploadFile'(
@@ -717,10 +1087,30 @@ export interface OperationMethods {
    * 
    */
   'saveFile'(
-    parameters?: Parameters<UnknownParamsObject> | null,
+    parameters?: Parameters<Paths.SaveFile.QueryParameters> | null,
     data?: Paths.SaveFile.RequestBody,
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.SaveFile.Responses.$201>
+  /**
+   * getFile - getFile
+   * 
+   * Get a file entity by id
+   */
+  'getFile'(
+    parameters?: Parameters<Paths.GetFile.QueryParameters & Paths.GetFile.PathParameters> | null,
+    data?: any,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.GetFile.Responses.$200>
+  /**
+   * deleteFile - deleteFile
+   * 
+   * Delete a file entity by id
+   */
+  'deleteFile'(
+    parameters?: Parameters<Paths.DeleteFile.QueryParameters & Paths.DeleteFile.PathParameters> | null,
+    data?: any,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.DeleteFile.Responses.$200>
   /**
    * downloadFile - downloadFile
    * 
@@ -732,26 +1122,6 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.DownloadFile.Responses.$200>
   /**
-   * verifyCustomDownloadUrl - verifyCustomDownloadUrl
-   * 
-   * Verify a pre-signed custom download url for a file
-   */
-  'verifyCustomDownloadUrl'(
-    parameters?: Parameters<UnknownParamsObject> | null,
-    data?: Paths.VerifyCustomDownloadUrl.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.VerifyCustomDownloadUrl.Responses.$200>
-  /**
-   * downloadFiles - downloadFiles
-   * 
-   * Generate pre-signed download S3 urls for multiple files
-   */
-  'downloadFiles'(
-    parameters?: Parameters<UnknownParamsObject> | null,
-    data?: Paths.DownloadFiles.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.DownloadFiles.Responses.$200>
-  /**
    * downloadS3File - downloadS3File
    * 
    * Generate pre-signed download S3 url for a file
@@ -762,22 +1132,22 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.DownloadS3File.Responses.$200>
   /**
+   * downloadFiles - downloadFiles
+   * 
+   * Bulk generate pre-signed download S3 urls for multiple files
+   */
+  'downloadFiles'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.DownloadFiles.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.DownloadFiles.Responses.$200>
+  /**
    * previewFile - previewFile
    * 
    * Generate thumbnail preview for a file entity
    */
   'previewFile'(
     parameters?: Parameters<Paths.PreviewFile.QueryParameters & Paths.PreviewFile.PathParameters> | null,
-    data?: any,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<any>
-  /**
-   * previewPublicFile - previewPublicFile
-   * 
-   * Generate thumbnail preview for a public file entity
-   */
-  'previewPublicFile'(
-    parameters?: Parameters<Paths.PreviewPublicFile.QueryParameters & Paths.PreviewPublicFile.PathParameters> | null,
     data?: any,
     config?: AxiosRequestConfig  
   ): OperationResponse<any>
@@ -802,15 +1172,15 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<any>
   /**
-   * deleteFile - deleteFile
+   * previewPublicFile - previewPublicFile
    * 
-   * Delete file entity
+   * Generate thumbnail preview for a public file entity
    */
-  'deleteFile'(
-    parameters?: Parameters<UnknownParamsObject> | null,
-    data?: Paths.DeleteFile.RequestBody,
+  'previewPublicFile'(
+    parameters?: Parameters<Paths.PreviewPublicFile.QueryParameters & Paths.PreviewPublicFile.PathParameters> | null,
+    data?: any,
     config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.DeleteFile.Responses.$200>
+  ): OperationResponse<any>
   /**
    * getSession - getSession
    * 
@@ -835,19 +1205,19 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.DeleteSession.Responses.$200>
   /**
-   * getAllPublicLinksForFile - getAllPublicLinksForFile
+   * listPublicLinksForFile - listPublicLinksForFile
    * 
-   * Not yet implemented; This API would fetches all the public links that are previously generated for a file
+   * Not yet implemented; This API would fetch all the public links that are previously generated for a file
    */
-  'getAllPublicLinksForFile'(
-    parameters?: Parameters<Paths.GetAllPublicLinksForFile.PathParameters> | null,
+  'listPublicLinksForFile'(
+    parameters?: Parameters<Paths.ListPublicLinksForFile.PathParameters> | null,
     data?: any,
     config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.GetAllPublicLinksForFile.Responses.$200>
+  ): OperationResponse<Paths.ListPublicLinksForFile.Responses.$200>
   /**
    * generatePublicLink - generatePublicLink
    * 
-   * Generates a public link to access the private files
+   * Generates a public link to access a private file
    * 
    */
   'generatePublicLink'(
@@ -861,14 +1231,14 @@ export interface OperationMethods {
    * Redirects to a accessible signed url for the respective file associated to the public link
    */
   'accessPublicLink'(
-    parameters?: Parameters<Paths.AccessPublicLink.PathParameters> | null,
+    parameters?: Parameters<Paths.AccessPublicLink.QueryParameters & Paths.AccessPublicLink.PathParameters> | null,
     data?: any,
     config?: AxiosRequestConfig  
   ): OperationResponse<any>
   /**
    * revokePublicLink - revokePublicLink
    * 
-   * Not yet implemented; This operation would revokes a given public link by ID
+   * Not yet implemented; This operation would revoke a given public link by ID
    */
   'revokePublicLink'(
     parameters?: Parameters<Paths.RevokePublicLink.PathParameters> | null,
@@ -876,50 +1246,60 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.RevokePublicLink.Responses.$204>
   /**
-   * uploadFileV2 - uploadFileV2
+   * verifyCustomDownloadUrl - verifyCustomDownloadUrl
    * 
-   * Create pre-signed S3 URL to upload a file to keep temporarily (one week). - v2
-   * 
-   * Use the createFile operation to store file file permanently.
-   * 
+   * Verify a pre-signed custom download url for a file
    */
-  'uploadFileV2'(
-    parameters?: Parameters<Paths.UploadFileV2.QueryParameters> | null,
-    data?: Paths.UploadFileV2.RequestBody,
-    config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.UploadFileV2.Responses.$201>
-  /**
-   * saveFileV2 - saveFileV2
-   * 
-   * Create / Update a permanent File entity
-   * 
-   * Makes file object permanent
-   * 
-   * Saves metadata to file entity
-   * 
-   */
-  'saveFileV2'(
+  'verifyCustomDownloadUrl'(
     parameters?: Parameters<UnknownParamsObject> | null,
-    data?: Paths.SaveFileV2.RequestBody,
+    data?: Paths.VerifyCustomDownloadUrl.RequestBody,
     config?: AxiosRequestConfig  
-  ): OperationResponse<Paths.SaveFileV2.Responses.$201>
+  ): OperationResponse<Paths.VerifyCustomDownloadUrl.Responses.$200>
+  /**
+   * uploadFilePublic - uploadFilePublic
+   * 
+   * Create pre-signed S3 URL to upload a file to keep temporarily (one week).
+   * 
+   * Use the saveFileV2 operation to store file file permanently.
+   * 
+   */
+  'uploadFilePublic'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.UploadFilePublic.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.UploadFilePublic.Responses.$201>
 }
 
 export interface PathsDictionary {
-  ['/v1/files/public/upload']: {
+  ['/v2/files/upload']: {
     /**
-     * uploadFilePublic - uploadFilePublic
+     * uploadFileV2 - uploadFileV2
      * 
      * Create pre-signed S3 URL to upload a file to keep temporarily (one week).
      * 
-     * Use the createFile operation to store file file permanently.
+     * Use the saveFileV2 operation to store file file permanently.
      * 
      */
     'post'(
-      parameters?: Parameters<UnknownParamsObject> | null,
-      data?: Paths.UploadFilePublic.RequestBody,
+      parameters?: Parameters<Paths.UploadFileV2.QueryParameters> | null,
+      data?: Paths.UploadFileV2.RequestBody,
       config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.UploadFilePublic.Responses.$201>
+    ): OperationResponse<Paths.UploadFileV2.Responses.$201>
+  }
+  ['/v2/files']: {
+    /**
+     * saveFileV2 - saveFileV2
+     * 
+     * Saves a permanent file entity. Updates an existing file entity when `_id` is passed.
+     * 
+     * Saves metadata to file entity and stores a version when `s3ref` or `source_url` is passed.
+     * 
+     */
+    'post'(
+      parameters?: Parameters<Paths.SaveFileV2.QueryParameters> | null,
+      data?: Paths.SaveFileV2.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.SaveFileV2.Responses.$200>
   }
   ['/v1/files/upload']: {
     /**
@@ -927,7 +1307,7 @@ export interface PathsDictionary {
      * 
      * Create pre-signed S3 URL to upload a file to keep temporarily (one week).
      * 
-     * Use the createFile operation to store file file permanently.
+     * Use the saveFile operation to store file file permanently.
      * 
      */
     'post'(
@@ -948,10 +1328,32 @@ export interface PathsDictionary {
      * 
      */
     'post'(
-      parameters?: Parameters<UnknownParamsObject> | null,
+      parameters?: Parameters<Paths.SaveFile.QueryParameters> | null,
       data?: Paths.SaveFile.RequestBody,
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.SaveFile.Responses.$201>
+  }
+  ['/v2/files/{id}']: {
+    /**
+     * getFile - getFile
+     * 
+     * Get a file entity by id
+     */
+    'get'(
+      parameters?: Parameters<Paths.GetFile.QueryParameters & Paths.GetFile.PathParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.GetFile.Responses.$200>
+    /**
+     * deleteFile - deleteFile
+     * 
+     * Delete a file entity by id
+     */
+    'delete'(
+      parameters?: Parameters<Paths.DeleteFile.QueryParameters & Paths.DeleteFile.PathParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.DeleteFile.Responses.$200>
   }
   ['/v1/files/{id}/download']: {
     /**
@@ -965,30 +1367,6 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.DownloadFile.Responses.$200>
   }
-  ['/v1/files/download:verify']: {
-    /**
-     * verifyCustomDownloadUrl - verifyCustomDownloadUrl
-     * 
-     * Verify a pre-signed custom download url for a file
-     */
-    'post'(
-      parameters?: Parameters<UnknownParamsObject> | null,
-      data?: Paths.VerifyCustomDownloadUrl.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.VerifyCustomDownloadUrl.Responses.$200>
-  }
-  ['/v1/files:downloadFiles']: {
-    /**
-     * downloadFiles - downloadFiles
-     * 
-     * Generate pre-signed download S3 urls for multiple files
-     */
-    'post'(
-      parameters?: Parameters<UnknownParamsObject> | null,
-      data?: Paths.DownloadFiles.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.DownloadFiles.Responses.$200>
-  }
   ['/v1/files:downloadS3']: {
     /**
      * downloadS3File - downloadS3File
@@ -1001,6 +1379,18 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.DownloadS3File.Responses.$200>
   }
+  ['/v1/files:downloadFiles']: {
+    /**
+     * downloadFiles - downloadFiles
+     * 
+     * Bulk generate pre-signed download S3 urls for multiple files
+     */
+    'post'(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.DownloadFiles.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.DownloadFiles.Responses.$200>
+  }
   ['/v1/files/{id}/preview']: {
     /**
      * previewFile - previewFile
@@ -1009,6 +1399,28 @@ export interface PathsDictionary {
      */
     'get'(
       parameters?: Parameters<Paths.PreviewFile.QueryParameters & Paths.PreviewFile.PathParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<any>
+  }
+  ['/v1/files:previewS3']: {
+    /**
+     * previewS3File - previewS3File
+     * 
+     * Generate thumbnail preview from an s3 reference for a file entity
+     */
+    'post'(
+      parameters?: Parameters<Paths.PreviewS3File.QueryParameters> | null,
+      data?: Paths.PreviewS3File.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<any>
+    /**
+     * previewS3FileGet - previewS3FileGet
+     * 
+     * Get thumbnail preview from an s3 reference for a file entity
+     */
+    'get'(
+      parameters?: Parameters<Paths.PreviewS3FileGet.QueryParameters> | null,
       data?: any,
       config?: AxiosRequestConfig  
     ): OperationResponse<any>
@@ -1024,40 +1436,6 @@ export interface PathsDictionary {
       data?: any,
       config?: AxiosRequestConfig  
     ): OperationResponse<any>
-  }
-  ['/v1/files:previewS3']: {
-    /**
-     * previewS3FileGet - previewS3FileGet
-     * 
-     * Get thumbnail preview from an s3 reference for a file entity
-     */
-    'get'(
-      parameters?: Parameters<Paths.PreviewS3FileGet.QueryParameters> | null,
-      data?: any,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<any>
-    /**
-     * previewS3File - previewS3File
-     * 
-     * Generate thumbnail preview from an s3 reference for a file entity
-     */
-    'post'(
-      parameters?: Parameters<Paths.PreviewS3File.QueryParameters> | null,
-      data?: Paths.PreviewS3File.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<any>
-  }
-  ['/v1/files/delete']: {
-    /**
-     * deleteFile - deleteFile
-     * 
-     * Delete file entity
-     */
-    'delete'(
-      parameters?: Parameters<UnknownParamsObject> | null,
-      data?: Paths.DeleteFile.RequestBody,
-      config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.DeleteFile.Responses.$200>
   }
   ['/v1/files/session']: {
     /**
@@ -1088,7 +1466,7 @@ export interface PathsDictionary {
     /**
      * generatePublicLink - generatePublicLink
      * 
-     * Generates a public link to access the private files
+     * Generates a public link to access a private file
      * 
      */
     'post'(
@@ -1097,15 +1475,15 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.GeneratePublicLink.Responses.$201>
     /**
-     * getAllPublicLinksForFile - getAllPublicLinksForFile
+     * listPublicLinksForFile - listPublicLinksForFile
      * 
-     * Not yet implemented; This API would fetches all the public links that are previously generated for a file
+     * Not yet implemented; This API would fetch all the public links that are previously generated for a file
      */
     'get'(
-      parameters?: Parameters<Paths.GetAllPublicLinksForFile.PathParameters> | null,
+      parameters?: Parameters<Paths.ListPublicLinksForFile.PathParameters> | null,
       data?: any,
       config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.GetAllPublicLinksForFile.Responses.$200>
+    ): OperationResponse<Paths.ListPublicLinksForFile.Responses.$200>
   }
   ['/v1/files/public/links/{id}/{filename}']: {
     /**
@@ -1114,7 +1492,7 @@ export interface PathsDictionary {
      * Redirects to a accessible signed url for the respective file associated to the public link
      */
     'get'(
-      parameters?: Parameters<Paths.AccessPublicLink.PathParameters> | null,
+      parameters?: Parameters<Paths.AccessPublicLink.QueryParameters & Paths.AccessPublicLink.PathParameters> | null,
       data?: any,
       config?: AxiosRequestConfig  
     ): OperationResponse<any>
@@ -1123,7 +1501,7 @@ export interface PathsDictionary {
     /**
      * revokePublicLink - revokePublicLink
      * 
-     * Not yet implemented; This operation would revokes a given public link by ID
+     * Not yet implemented; This operation would revoke a given public link by ID
      */
     'delete'(
       parameters?: Parameters<Paths.RevokePublicLink.PathParameters> | null,
@@ -1131,55 +1509,58 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.RevokePublicLink.Responses.$204>
   }
-  ['/v2/files/upload']: {
+  ['/v1/files/download:verify']: {
     /**
-     * uploadFileV2 - uploadFileV2
+     * verifyCustomDownloadUrl - verifyCustomDownloadUrl
      * 
-     * Create pre-signed S3 URL to upload a file to keep temporarily (one week). - v2
-     * 
-     * Use the createFile operation to store file file permanently.
-     * 
+     * Verify a pre-signed custom download url for a file
      */
     'post'(
-      parameters?: Parameters<Paths.UploadFileV2.QueryParameters> | null,
-      data?: Paths.UploadFileV2.RequestBody,
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.VerifyCustomDownloadUrl.RequestBody,
       config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.UploadFileV2.Responses.$201>
+    ): OperationResponse<Paths.VerifyCustomDownloadUrl.Responses.$200>
   }
-  ['/v2/files']: {
+  ['/v1/files/public/upload']: {
     /**
-     * saveFileV2 - saveFileV2
+     * uploadFilePublic - uploadFilePublic
      * 
-     * Create / Update a permanent File entity
+     * Create pre-signed S3 URL to upload a file to keep temporarily (one week).
      * 
-     * Makes file object permanent
-     * 
-     * Saves metadata to file entity
+     * Use the saveFileV2 operation to store file file permanently.
      * 
      */
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
-      data?: Paths.SaveFileV2.RequestBody,
+      data?: Paths.UploadFilePublic.RequestBody,
       config?: AxiosRequestConfig  
-    ): OperationResponse<Paths.SaveFileV2.Responses.$201>
+    ): OperationResponse<Paths.UploadFilePublic.Responses.$201>
   }
 }
 
 export type Client = OpenAPIClient<OperationMethods, PathsDictionary>
 
+
+export type ActivityId = Components.Schemas.ActivityId;
+export type BaseEntityAcl = Components.Schemas.BaseEntityAcl;
+export type BaseEntityOwner = Components.Schemas.BaseEntityOwner;
 export type CommonSaveFilePayload = Components.Schemas.CommonSaveFilePayload;
-export type DeleteFilePayload = Components.Schemas.DeleteFilePayload;
+export type CustomDownloadUrl = Components.Schemas.CustomDownloadUrl;
 export type DownloadFilesPayload = Components.Schemas.DownloadFilesPayload;
 export type EntityId = Components.Schemas.EntityId;
 export type EntitySlug = Components.Schemas.EntitySlug;
+export type FileAttributes = Components.Schemas.FileAttributes;
 export type FileEntity = Components.Schemas.FileEntity;
 export type FileEntityId = Components.Schemas.FileEntityId;
 export type FileItem = Components.Schemas.FileItem;
 export type FileRelationItem = Components.Schemas.FileRelationItem;
+export type FileType = Components.Schemas.FileType;
 export type FileUpload = Components.Schemas.FileUpload;
 export type PublicLink = Components.Schemas.PublicLink;
+export type S3Ref = Components.Schemas.S3Ref;
 export type S3Reference = Components.Schemas.S3Reference;
 export type SaveCustomFilePayload = Components.Schemas.SaveCustomFilePayload;
+export type SaveFileFromSourceURLPayload = Components.Schemas.SaveFileFromSourceURLPayload;
 export type SaveFilePayload = Components.Schemas.SaveFilePayload;
 export type SaveFilePayloadV2 = Components.Schemas.SaveFilePayloadV2;
 export type SaveS3FilePayload = Components.Schemas.SaveS3FilePayload;

--- a/clients/file-client/src/openapi.json
+++ b/clients/file-client/src/openapi.json
@@ -2,17 +2,52 @@
   "openapi": "3.0.3",
   "info": {
     "title": "File API",
-    "version": "0.1.0",
-    "description": "Upload and manage all files stored in epilot"
+    "version": "0.2.0",
+    "description": "Upload and manage epilot Files"
   },
   "tags": [
     {
-      "name": "files",
-      "description": "Files API"
+      "name": "File",
+      "description": "Upload and Manage File Entities"
     },
     {
-      "name": "session",
+      "name": "Preview",
+      "description": "Preview APIs"
+    },
+    {
+      "name": "Public Links",
+      "description": "Create and Manage Public Links for Files"
+    },
+    {
+      "name": "Session",
       "description": "Session API for cookie authentication"
+    },
+    {
+      "name": "Deprecated",
+      "description": "Deprecated APIs"
+    },
+    {
+      "name": "file_schema",
+      "x-displayName": "File",
+      "description": "<SchemaDefinition schemaRef=\"#/components/schemas/FileEntity\" />\n"
+    }
+  ],
+  "x-tagGroups": [
+    {
+      "name": "APIs",
+      "tags": [
+        "File",
+        "Preview",
+        "Public Links",
+        "Session",
+        "Deprecated"
+      ]
+    },
+    {
+      "name": "Schemas",
+      "tags": [
+        "file_schema"
+      ]
     }
   ],
   "security": [
@@ -24,14 +59,184 @@
     }
   ],
   "paths": {
-    "/v1/files/public/upload": {
+    "/v2/files/upload": {
       "post": {
-        "operationId": "uploadFilePublic",
-        "summary": "uploadFilePublic",
-        "security": [],
-        "description": "Create pre-signed S3 URL to upload a file to keep temporarily (one week).\n\nUse the createFile operation to store file file permanently.\n",
+        "operationId": "uploadFileV2",
+        "summary": "uploadFileV2",
+        "description": "Create pre-signed S3 URL to upload a file to keep temporarily (one week).\n\nUse the saveFileV2 operation to store file file permanently.\n",
         "tags": [
-          "files"
+          "File"
+        ],
+        "parameters": [
+          {
+            "name": "file_entity_id",
+            "in": "query",
+            "description": "Use this parameter when uploading a file directly to an existing file entity.\n\nNote: still requires calling saveFileV2 to save the file permanently.\n",
+            "schema": {
+              "$ref": "#/components/schemas/FileEntityId"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadFilePayload"
+              },
+              "examples": {
+                "Upload an image file": {
+                  "description": "Upload an image file",
+                  "value": {
+                    "filename": "image.png",
+                    "mime_type": "image/png"
+                  }
+                },
+                "Upload a document": {
+                  "description": "Upload an image file",
+                  "value": {
+                    "filename": "document.pdf",
+                    "mime_type": "application/pdf"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Pre-signed URL for POST / PUT upload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileUpload"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/files": {
+      "post": {
+        "operationId": "saveFileV2",
+        "summary": "saveFileV2",
+        "description": "Saves a permanent file entity. Updates an existing file entity when `_id` is passed.\n\nSaves metadata to file entity and stores a version when `s3ref` or `source_url` is passed.\n",
+        "tags": [
+          "File"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ActivityIdQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/FillActivityQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/StrictQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/AsyncOperationQueryParam"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SaveFilePayloadV2"
+              },
+              "examples": {
+                "New file from s3ref": {
+                  "description": "Standard epilot file entity with S3 Ref",
+                  "value": {
+                    "type": "document",
+                    "filename": "document.pdf",
+                    "_tags": [
+                      "string"
+                    ],
+                    "access_control": "private",
+                    "s3ref": {
+                      "bucket": "epilot-prod-user-content",
+                      "key": "123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
+                    }
+                  }
+                },
+                "Update existing file with relations": {
+                  "description": "Update existing file entity with _id",
+                  "value": {
+                    "_id": "ef7d985c-2385-44f4-9c71-ae06a52264f8",
+                    "filename": "document.pdf",
+                    "access_control": "private",
+                    "custom_download_url": "https://some-api-url.com/download?file_id=123",
+                    "shared_with_end_customer": true,
+                    "relations": [
+                      {
+                        "entity_id": "77a1e0cc-7b92-4d41-8cce-eefd317ec004",
+                        "_schema": "contact"
+                      }
+                    ]
+                  }
+                },
+                "New file from source_url": {
+                  "description": "New epilot file entity from a source_url",
+                  "value": {
+                    "type": "document",
+                    "filename": "document.pdf",
+                    "_tags": [
+                      "string"
+                    ],
+                    "access_control": "private",
+                    "source_url": "https://docs.epilot.io/document.pdf"
+                  }
+                },
+                "File with custom download URL (external)": {
+                  "description": "Custom file entity with custom download url",
+                  "value": {
+                    "type": "document",
+                    "filename": "document.pdf",
+                    "_tags": [
+                      "string"
+                    ],
+                    "access_control": "private",
+                    "custom_download_url": "https://some-api-url.com/download?file_id=123",
+                    "shared_with_end_customer": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created File Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileEntity"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/files/upload": {
+      "post": {
+        "operationId": "uploadFile",
+        "summary": "uploadFile",
+        "deprecated": true,
+        "description": "Create pre-signed S3 URL to upload a file to keep temporarily (one week).\n\nUse the saveFile operation to store file file permanently.\n",
+        "tags": [
+          "Deprecated"
+        ],
+        "parameters": [
+          {
+            "name": "file_entity_id",
+            "in": "query",
+            "description": "file entity id",
+            "schema": {
+              "$ref": "#/components/schemas/FileEntityId"
+            }
+          }
         ],
         "requestBody": {
           "content": {
@@ -53,11 +258,11 @@
                     "s3ref": {
                       "allOf": [
                         {
-                          "$ref": "#/components/schemas/S3Reference"
+                          "$ref": "#/components/schemas/S3Ref"
                         },
                         {
                           "example": {
-                            "bucket": "epilot-files-prod",
+                            "bucket": "epilot-prod-user-content",
                             "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
                           }
                         }
@@ -66,75 +271,13 @@
                     "upload_url": {
                       "type": "string",
                       "format": "url",
-                      "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/files/upload": {
-      "post": {
-        "operationId": "uploadFile",
-        "summary": "uploadFile",
-        "description": "Create pre-signed S3 URL to upload a file to keep temporarily (one week).\n\nUse the createFile operation to store file file permanently.\n",
-        "tags": [
-          "files"
-        ],
-        "parameters": [
-          {
-            "name": "file_entity_id",
-            "in": "query",
-            "description": "file entity id",
-            "schema": {
-              "$ref": "#/components/schemas/FileEntityId"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UploadFilePayload",
-                "type": "object"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Pre-signed URL for POST / PUT upload",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "s3ref": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/S3Reference"
-                        },
-                        {
-                          "example": {
-                            "bucket": "epilot-files-prod",
-                            "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
-                          }
-                        }
-                      ]
-                    },
-                    "upload_url": {
-                      "type": "string",
-                      "format": "url",
-                      "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
+                      "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
                     },
                     "public_url": {
                       "description": "Returned only if file is permanent i.e. file_entity_id is passed",
                       "type": "string",
                       "format": "url",
-                      "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
+                      "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
                     }
                   }
                 }
@@ -148,67 +291,24 @@
       "post": {
         "operationId": "saveFile",
         "summary": "saveFile",
+        "deprecated": true,
         "description": "Create / Update a permanent File entity\n\nMakes file object permanent\n\nSaves metadata to file entity\n",
         "tags": [
-          "files"
+          "Deprecated"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ActivityIdQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/AsyncOperationQueryParam"
+          }
         ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SaveFilePayload"
-              },
-              "examples": {
-                "S3File": {
-                  "description": "Standard epilot file entity with S3 Ref",
-                  "value": {
-                    "file_entity_id": "string",
-                    "document_type": "document",
-                    "filename": "document.pdf",
-                    "_tags": [
-                      "string"
-                    ],
-                    "access_control": "private",
-                    "s3ref": {
-                      "bucket": "epilot-files-prod",
-                      "key": "123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
-                    }
-                  }
-                },
-                "CustomFile": {
-                  "description": "Custom file entity with custom download url",
-                  "value": {
-                    "file_entity_id": "string",
-                    "document_type": "document",
-                    "filename": "document.pdf",
-                    "_tags": [
-                      "string"
-                    ],
-                    "access_control": "private",
-                    "custom_download_url": "https://some-api-url.com/download?file_id=123",
-                    "shared_with_end_customer": true
-                  }
-                },
-                "CustomFileWithRelations": {
-                  "description": "Custom file entity with custom download url",
-                  "value": {
-                    "file_entity_id": "string",
-                    "document_type": "document",
-                    "filename": "document.pdf",
-                    "_tags": [
-                      "string"
-                    ],
-                    "access_control": "private",
-                    "custom_download_url": "https://some-api-url.com/download?file_id=123",
-                    "shared_with_end_customer": true,
-                    "relations": [
-                      {
-                        "entity_id": "77a1e0cc-7b92-4d41-8cce-eefd317ec004",
-                        "_schema": "contact"
-                      }
-                    ]
-                  }
-                }
               }
             }
           }
@@ -227,13 +327,104 @@
         }
       }
     },
+    "/v2/files/{id}": {
+      "get": {
+        "operationId": "getFile",
+        "summary": "getFile",
+        "description": "Get a file entity by id",
+        "tags": [
+          "File"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/FileEntityId"
+            }
+          },
+          {
+            "name": "source_url",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "description": "Generate a source_url for the file entity, if it doesn't have one"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/StrictQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/AsyncOperationQueryParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "File Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileEntity"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteFile",
+        "summary": "deleteFile",
+        "description": "Delete a file entity by id",
+        "tags": [
+          "File"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/FileEntityId"
+            }
+          },
+          {
+            "name": "purge",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "$ref": "#/components/parameters/ActivityIdQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/StrictQueryParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The deleted file",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileEntity"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/files/{id}/download": {
       "get": {
         "operationId": "downloadFile",
         "summary": "downloadFile",
         "description": "Generate pre-signed download S3 url for a file",
         "tags": [
-          "files"
+          "File"
         ],
         "parameters": [
           {
@@ -274,88 +465,7 @@
                     "download_url": {
                       "type": "string",
                       "format": "uri",
-                      "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/files/download:verify": {
-      "post": {
-        "operationId": "verifyCustomDownloadUrl",
-        "summary": "verifyCustomDownloadUrl",
-        "description": "Verify a pre-signed custom download url for a file",
-        "tags": [
-          "files"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/VerifyCustomDownloadUrlPayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Download Url matches signature and has not expired",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "valid": {
-                      "type": "boolean"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/files:downloadFiles": {
-      "post": {
-        "operationId": "downloadFiles",
-        "summary": "downloadFiles",
-        "description": "Generate pre-signed download S3 urls for multiple files",
-        "tags": [
-          "files"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DownloadFilesPayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Generated download urls",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "download_url": {
-                        "type": "string",
-                        "format": "uri",
-                        "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
-                      },
-                      "file_entity_id": {
-                        "type": "string",
-                        "format": "uuid"
-                      }
+                      "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
                     }
                   }
                 }
@@ -371,7 +481,7 @@
         "summary": "downloadS3File",
         "description": "Generate pre-signed download S3 url for a file",
         "tags": [
-          "files"
+          "File"
         ],
         "parameters": [
           {
@@ -411,7 +521,52 @@
                     "download_url": {
                       "type": "string",
                       "format": "uri",
-                      "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
+                      "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/files:downloadFiles": {
+      "post": {
+        "operationId": "downloadFiles",
+        "summary": "downloadFiles",
+        "description": "Bulk generate pre-signed download S3 urls for multiple files",
+        "tags": [
+          "File"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadFilesPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated download urls",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "download_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
+                      },
+                      "file_entity_id": {
+                        "type": "string",
+                        "format": "uuid"
+                      }
                     }
                   }
                 }
@@ -427,7 +582,7 @@
         "summary": "previewFile",
         "description": "Generate thumbnail preview for a file entity",
         "tags": [
-          "files"
+          "Preview"
         ],
         "parameters": [
           {
@@ -475,6 +630,105 @@
         }
       }
     },
+    "/v1/files:previewS3": {
+      "post": {
+        "operationId": "previewS3File",
+        "summary": "previewS3File",
+        "description": "Generate thumbnail preview from an s3 reference for a file entity",
+        "tags": [
+          "Preview"
+        ],
+        "parameters": [
+          {
+            "name": "w",
+            "in": "query",
+            "description": "width",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "h",
+            "in": "query",
+            "description": "height",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/S3Ref"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Generated thumbnail image",
+            "content": {
+              "image/png": {},
+              "image/jpeg": {}
+            }
+          }
+        }
+      },
+      "get": {
+        "operationId": "previewS3FileGet",
+        "summary": "previewS3FileGet",
+        "description": "Get thumbnail preview from an s3 reference for a file entity",
+        "tags": [
+          "Preview"
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "description": "s3 key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "bucket",
+            "in": "query",
+            "description": "s3 bucket",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "w",
+            "in": "query",
+            "description": "width",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "h",
+            "in": "query",
+            "description": "height",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Generated thumbnail image",
+            "content": {
+              "image/png": {},
+              "image/jpeg": {}
+            }
+          }
+        }
+      }
+    },
     "/v1/files/public/{id}/preview": {
       "get": {
         "operationId": "previewPublicFile",
@@ -482,7 +736,7 @@
         "description": "Generate thumbnail preview for a public file entity",
         "security": [],
         "tags": [
-          "files"
+          "Preview"
         ],
         "parameters": [
           {
@@ -538,136 +792,13 @@
         }
       }
     },
-    "/v1/files:previewS3": {
-      "get": {
-        "operationId": "previewS3FileGet",
-        "summary": "previewS3FileGet",
-        "description": "Get thumbnail preview from an s3 reference for a file entity",
-        "tags": [
-          "files"
-        ],
-        "parameters": [
-          {
-            "name": "key",
-            "in": "query",
-            "description": "s3 key",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "bucket",
-            "in": "query",
-            "description": "s3 bucket",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "w",
-            "in": "query",
-            "description": "width",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "h",
-            "in": "query",
-            "description": "height",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Generated thumbnail image",
-            "content": {
-              "image/png": {},
-              "image/jpeg": {}
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "previewS3File",
-        "summary": "previewS3File",
-        "description": "Generate thumbnail preview from an s3 reference for a file entity",
-        "tags": [
-          "files"
-        ],
-        "parameters": [
-          {
-            "name": "w",
-            "in": "query",
-            "description": "width",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "h",
-            "in": "query",
-            "description": "height",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/S3Reference"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Generated thumbnail image",
-            "content": {
-              "image/png": {},
-              "image/jpeg": {}
-            }
-          }
-        }
-      }
-    },
-    "/v1/files/delete": {
-      "delete": {
-        "operationId": "deleteFile",
-        "summary": "deleteFile",
-        "description": "Delete file entity",
-        "tags": [
-          "files"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/DeleteFilePayload"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "File delete response"
-          }
-        }
-      }
-    },
     "/v1/files/session": {
       "get": {
         "operationId": "getSession",
         "summary": "getSession",
         "description": "Start a browser session by setting passed Authorization token in a server side cookie.\n\nAllows using preview urls directly in img src for private files using cookie authentication.\n",
         "tags": [
-          "session"
+          "Session"
         ],
         "responses": {
           "200": {
@@ -680,7 +811,7 @@
         "summary": "deleteSession",
         "description": "End browser session by deleting token cookie",
         "tags": [
-          "session"
+          "Session"
         ],
         "responses": {
           "200": {
@@ -693,9 +824,9 @@
       "post": {
         "operationId": "generatePublicLink",
         "summary": "generatePublicLink",
-        "description": "Generates a public link to access the private files\n",
+        "description": "Generates a public link to access a private file\n",
         "tags": [
-          "files"
+          "Public Links"
         ],
         "parameters": [
           {
@@ -722,9 +853,9 @@
         }
       },
       "get": {
-        "operationId": "getAllPublicLinksForFile",
-        "summary": "getAllPublicLinksForFile",
-        "description": "Not yet implemented; This API would fetches all the public links that are previously generated for a file",
+        "operationId": "listPublicLinksForFile",
+        "summary": "listPublicLinksForFile",
+        "description": "Not yet implemented; This API would fetch all the public links that are previously generated for a file",
         "x-not-implemented": true,
         "parameters": [
           {
@@ -739,7 +870,7 @@
           }
         ],
         "tags": [
-          "files"
+          "Public Links"
         ],
         "responses": {
           "200": {
@@ -768,6 +899,9 @@
         "operationId": "accessPublicLink",
         "summary": "accessPublicLink",
         "security": [],
+        "tags": [
+          "Public Links"
+        ],
         "description": "Redirects to a accessible signed url for the respective file associated to the public link",
         "parameters": [
           {
@@ -789,10 +923,16 @@
               "description": "Name of the file",
               "example": "invoice-2023-12.pdf"
             }
+          },
+          {
+            "name": "hash",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "An optional cache-busting hash for the file"
+            }
           }
-        ],
-        "tags": [
-          "files"
         ],
         "responses": {
           "302": {
@@ -805,8 +945,7 @@
       "delete": {
         "operationId": "revokePublicLink",
         "summary": "revokePublicLink",
-        "security": [],
-        "description": "Not yet implemented; This operation would revokes a given public link by ID",
+        "description": "Not yet implemented; This operation would revoke a given public link by ID",
         "x-not-implemented": true,
         "parameters": [
           {
@@ -821,7 +960,7 @@
           }
         ],
         "tags": [
-          "files"
+          "Public Links"
         ],
         "responses": {
           "204": {
@@ -838,30 +977,72 @@
         }
       }
     },
-    "/v2/files/upload": {
+    "/v1/files/download:verify": {
       "post": {
-        "operationId": "uploadFileV2",
-        "summary": "uploadFileV2",
-        "description": "Create pre-signed S3 URL to upload a file to keep temporarily (one week). - v2\n\nUse the createFile operation to store file file permanently.\n",
+        "operationId": "verifyCustomDownloadUrl",
+        "summary": "verifyCustomDownloadUrl",
+        "description": "Verify a pre-signed custom download url for a file",
         "tags": [
-          "files"
-        ],
-        "parameters": [
-          {
-            "name": "file_entity_id",
-            "in": "query",
-            "description": "file entity id",
-            "schema": {
-              "$ref": "#/components/schemas/FileEntityId"
-            }
-          }
+          "File"
         ],
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UploadFilePayload",
-                "type": "object"
+                "$ref": "#/components/schemas/VerifyCustomDownloadUrlPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Download Url matches signature and has not expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "valid": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/files/public/upload": {
+      "post": {
+        "operationId": "uploadFilePublic",
+        "summary": "uploadFilePublic",
+        "security": [],
+        "description": "Create pre-signed S3 URL to upload a file to keep temporarily (one week).\n\nUse the saveFileV2 operation to store file file permanently.\n",
+        "tags": [
+          "File"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadFilePayload"
+              },
+              "examples": {
+                "Upload an image file": {
+                  "description": "Upload an image file",
+                  "value": {
+                    "filename": "image.png",
+                    "mime_type": "image/png"
+                  }
+                },
+                "Upload a document": {
+                  "description": "Upload an image file",
+                  "value": {
+                    "filename": "document.pdf",
+                    "mime_type": "application/pdf"
+                  }
+                }
               }
             }
           }
@@ -872,90 +1053,27 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FileUpload"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/files": {
-      "post": {
-        "operationId": "saveFileV2",
-        "summary": "saveFileV2",
-        "description": "Create / Update a permanent File entity\n\nMakes file object permanent\n\nSaves metadata to file entity\n",
-        "tags": [
-          "files"
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SaveFilePayloadV2"
-              },
-              "examples": {
-                "S3File": {
-                  "description": "Standard epilot file entity with S3 Ref",
-                  "value": {
-                    "file_entity_id": "string",
-                    "document_type": "document",
-                    "filename": "document.pdf",
-                    "_tags": [
-                      "string"
-                    ],
-                    "access_control": "private",
+                  "type": "object",
+                  "properties": {
                     "s3ref": {
-                      "bucket": "epilot-files-prod",
-                      "key": "123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/S3Ref"
+                        },
+                        {
+                          "example": {
+                            "bucket": "epilot-prod-user-content",
+                            "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
+                          }
+                        }
+                      ]
+                    },
+                    "upload_url": {
+                      "type": "string",
+                      "format": "url",
+                      "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
                     }
                   }
-                },
-                "CustomFile": {
-                  "description": "Custom file entity with custom download url",
-                  "value": {
-                    "file_entity_id": "string",
-                    "document_type": "document",
-                    "filename": "document.pdf",
-                    "_tags": [
-                      "string"
-                    ],
-                    "access_control": "private",
-                    "custom_download_url": "https://some-api-url.com/download?file_id=123",
-                    "shared_with_end_customer": true
-                  }
-                },
-                "CustomFileWithRelations": {
-                  "description": "Custom file entity with custom download url",
-                  "value": {
-                    "file_entity_id": "string",
-                    "document_type": "document",
-                    "filename": "document.pdf",
-                    "_tags": [
-                      "string"
-                    ],
-                    "access_control": "private",
-                    "custom_download_url": "https://some-api-url.com/download?file_id=123",
-                    "shared_with_end_customer": true,
-                    "relations": [
-                      {
-                        "entity_id": "77a1e0cc-7b92-4d41-8cce-eefd317ec004",
-                        "_schema": "contact"
-                      }
-                    ]
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Created File Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileEntity"
                 }
               }
             }
@@ -989,19 +1107,72 @@
         "type": "string",
         "example": "contact"
       },
+      "ActivityId": {
+        "type": "string",
+        "format": "ulid",
+        "description": "See https://github.com/ulid/spec",
+        "example": "01F130Q52Q6MWSNS8N2AVXV4JN"
+      },
       "FileEntityId": {
         "type": "string",
         "example": "ef7d985c-2385-44f4-9c71-ae06a52264f8"
       },
-      "FileEntity": {
+      "FileAttributes": {
         "type": "object",
         "properties": {
-          "_id": {
-            "$ref": "#/components/schemas/FileEntityId"
+          "_tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "tag1",
+              "tag2"
+            ]
+          },
+          "_purpose": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "8d396871-95a0-4c9d-bb4d-9eda9c35776c",
+              "da7cdf9a-01be-40c9-a29c-9a8f9f0de6f8"
+            ]
+          },
+          "_manifest": {
+            "type": "array",
+            "description": "Manifest ID used to create/update the entity",
+            "items": {
+              "type": "string",
+              "format": "uuid",
+              "example": "123e4567-e89b-12d3-a456-426614174000"
+            }
           },
           "filename": {
             "type": "string",
             "example": "document.pdf"
+          },
+          "type": {
+            "$ref": "#/components/schemas/FileType"
+          },
+          "mime_type": {
+            "type": "string",
+            "description": "MIME type of the file",
+            "example": "application/pdf"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "File size in bytes",
+            "example": 1234,
+            "readOnly": true
+          },
+          "readable_size": {
+            "type": "string",
+            "example": "1.2 MB",
+            "description": "Human readable file size",
+            "readOnly": true
           },
           "access_control": {
             "type": "string",
@@ -1015,48 +1186,232 @@
             "description": "Direct URL for file (public only if file access control is public-read)",
             "type": "string",
             "format": "url",
-            "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
+            "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf",
+            "readOnly": true
           },
-          "type": {
-            "description": "Human readable type for file",
-            "type": "string",
-            "enum": [
-              "document",
-              "document_template",
-              "text",
-              "image",
-              "video",
-              "audio",
-              "spreadsheet",
-              "presentation",
-              "font",
-              "archive",
-              "application",
-              "unknown"
+          "custom_download_url": {
+            "$ref": "#/components/schemas/CustomDownloadUrl"
+          }
+        }
+      },
+      "FileType": {
+        "type": "string",
+        "enum": [
+          "document",
+          "document_template",
+          "text",
+          "image",
+          "video",
+          "audio",
+          "spreadsheet",
+          "presentation",
+          "font",
+          "archive",
+          "application",
+          "unknown"
+        ]
+      },
+      "CustomDownloadUrl": {
+        "description": "Custom external download url used for the file",
+        "type": "string",
+        "format": "uri",
+        "example": "https://some-api-url.com/download?file_id=123"
+      },
+      "FileEntity": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "_title": {
+                "type": "string",
+                "example": "document.pdf"
+              },
+              "_schema": {
+                "type": "string",
+                "enum": [
+                  "file"
+                ],
+                "readOnly": true
+              },
+              "_org": {
+                "type": "string",
+                "example": "123",
+                "readOnly": true
+              },
+              "_id": {
+                "$ref": "#/components/schemas/FileEntityId"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/FileAttributes"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source_url": {
+                "type": "string",
+                "description": "Source URL for the file. Included if the entity was created from source_url, or when ?source_url=true",
+                "example": "https://productengineer-content.s3.eu-west-1.amazonaws.com/product-engineer-checklist.pdf"
+              },
+              "s3ref": {
+                "$ref": "#/components/schemas/S3Ref",
+                "readOnly": true
+              },
+              "versions": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FileItem"
+                },
+                "readOnly": true
+              },
+              "_updated_at": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "_created_at": {
+                "type": "string",
+                "format": "date-time",
+                "readOnly": true
+              },
+              "_acl": {
+                "$ref": "#/components/schemas/BaseEntityAcl"
+              },
+              "_owners": {
+                "type": "array",
+                "readOnly": true,
+                "items": {
+                  "$ref": "#/components/schemas/BaseEntityOwner"
+                }
+              },
+              "__additional": {
+                "type": "object",
+                "description": "Additional fields that are not part of the schema",
+                "additionalProperties": true,
+                "nullable": true
+              }
+            },
+            "required": [
+              "_title",
+              "_schema",
+              "_org",
+              "_id",
+              "filename",
+              "type",
+              "access_control",
+              "versions"
+            ]
+          }
+        ]
+      },
+      "CommonSaveFilePayload": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FileEntityId"
+              },
+              {
+                "description": "if passed, adds a new version to existing file entity"
+              }
             ]
           },
-          "mime_type": {
+          "file_entity_id": {
             "type": "string",
-            "description": "MIME type of the file",
-            "example": "application/pdf"
+            "description": "Deprecated, use _id instead",
+            "deprecated": true
           },
-          "size_bytes": {
-            "type": "integer",
-            "minimum": 0,
-            "description": "File size in bytes"
-          },
-          "versions": {
+          "relations": {
             "type": "array",
+            "description": "List of entities to relate the file to",
             "items": {
-              "type": "object",
-              "properties": {
-                "s3ref": {
-                  "$ref": "#/components/schemas/S3Reference"
-                }
+              "$ref": "#/components/schemas/FileRelationItem"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "SaveS3FilePayload": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommonSaveFilePayload"
+          },
+          {
+            "$ref": "#/components/schemas/FileAttributes"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "s3ref": {
+                "$ref": "#/components/schemas/S3Ref"
               }
             }
           }
-        }
+        ]
+      },
+      "SaveFileFromSourceURLPayload": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommonSaveFilePayload"
+          },
+          {
+            "$ref": "#/components/schemas/FileAttributes"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "source_url": {
+                "$ref": "#/components/schemas/CustomDownloadUrl"
+              }
+            }
+          }
+        ]
+      },
+      "SaveCustomFilePayload": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/CommonSaveFilePayload"
+          },
+          {
+            "$ref": "#/components/schemas/FileAttributes"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "custom_download_url": {
+                "$ref": "#/components/schemas/CustomDownloadUrl"
+              }
+            }
+          }
+        ]
+      },
+      "SaveFilePayload": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/SaveS3FilePayload"
+          },
+          {
+            "$ref": "#/components/schemas/SaveFileFromSourceURLPayload"
+          },
+          {
+            "$ref": "#/components/schemas/SaveCustomFilePayload"
+          }
+        ]
+      },
+      "SaveFilePayloadV2": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/SaveS3FilePayload"
+          },
+          {
+            "$ref": "#/components/schemas/SaveFileFromSourceURLPayload"
+          },
+          {
+            "$ref": "#/components/schemas/SaveCustomFilePayload"
+          }
+        ]
       },
       "UploadFilePayload": {
         "type": "object",
@@ -1102,11 +1457,11 @@
           "s3ref": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/S3Reference"
+                "$ref": "#/components/schemas/S3Ref"
               },
               {
                 "example": {
-                  "bucket": "epilot-files-prod",
+                  "bucket": "epilot-prod-user-content",
                   "key": "123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
                 }
               }
@@ -1115,13 +1470,13 @@
           "upload_url": {
             "type": "string",
             "format": "url",
-            "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
+            "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/temp/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf?AWSParams=123"
           },
           "public_url": {
             "description": "Returned only if file is permanent i.e. file_entity_id is passed",
             "type": "string",
             "format": "url",
-            "example": "https://epilot-files-prod.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
+            "example": "https://epilot-prod-user-content.s3.eu-central-1.amazonaws.com/123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
           }
         }
       },
@@ -1144,195 +1499,12 @@
           ]
         }
       },
-      "CommonSaveFilePayload": {
-        "type": "object",
-        "properties": {
-          "file_entity_id": {
-            "type": "string",
-            "description": "if passed, adds a new version to existing file entity"
-          },
-          "document_type": {
-            "type": "string",
-            "enum": [
-              "document",
-              "document_template",
-              "text",
-              "image",
-              "video",
-              "audio",
-              "spreadsheet",
-              "presentation",
-              "font",
-              "archive",
-              "application",
-              "unknown"
-            ]
-          },
-          "filename": {
-            "type": "string",
-            "example": "document.pdf"
-          },
-          "_tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "access_control": {
-            "type": "string",
-            "default": "private",
-            "enum": [
-              "private",
-              "public-read"
-            ]
-          },
-          "relations": {
-            "type": "array",
-            "description": "List of entities to relate the file to",
-            "items": {
-              "$ref": "#/components/schemas/FileRelationItem"
-            }
-          }
-        },
-        "additionalProperties": true
-      },
-      "SaveS3FilePayload": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CommonSaveFilePayload"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "s3ref": {
-                "$ref": "#/components/schemas/S3Reference"
-              }
-            },
-            "required": [
-              "s3ref"
-            ]
-          }
-        ]
-      },
-      "SaveCustomFilePayload": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/CommonSaveFilePayload"
-          },
-          {
-            "type": "object",
-            "properties": {
-              "custom_download_url": {
-                "description": "Custom external download url used for the file",
-                "type": "string",
-                "format": "uri"
-              }
-            },
-            "required": [
-              "custom_download_url"
-            ]
-          }
-        ]
-      },
-      "SaveFilePayload": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/SaveS3FilePayload"
-          },
-          {
-            "$ref": "#/components/schemas/SaveCustomFilePayload"
-          }
-        ]
-      },
-      "SaveFilePayloadV2": {
-        "type": "object",
-        "properties": {
-          "s3ref": {
-            "type": "object",
-            "properties": {
-              "bucket": {
-                "type": "string",
-                "example": "epilot-files-prod"
-              },
-              "key": {
-                "type": "string",
-                "example": "123/4d689aeb-1497-4410-a9fe-b36ca9ac4389/document.pdf"
-              }
-            },
-            "required": [
-              "bucket",
-              "key"
-            ]
-          },
-          "filename": {
-            "type": "string",
-            "example": "document.pdf"
-          },
-          "file_entity_id": {
-            "type": "string",
-            "description": "if passed, adds a new version to existing file entity"
-          },
-          "document_type": {
-            "type": "string",
-            "enum": [
-              "document",
-              "document_template",
-              "text",
-              "image",
-              "video",
-              "audio",
-              "spreadsheet",
-              "presentation",
-              "font",
-              "archive",
-              "application",
-              "unknown"
-            ]
-          },
-          "_tags": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "access_control": {
-            "type": "string",
-            "default": "private",
-            "enum": [
-              "private",
-              "public-read"
-            ]
-          },
-          "custom_download_url": {
-            "description": "Custom external download url used for the file",
-            "type": "string",
-            "format": "uri"
-          }
-        },
-        "additionalProperties": true,
-        "required": [
-          "s3ref",
-          "filename"
-        ]
-      },
-      "DeleteFilePayload": {
-        "type": "object",
-        "properties": {
-          "s3ref": {
-            "$ref": "#/components/schemas/S3Reference"
-          }
-        },
-        "required": [
-          "s3ref"
-        ]
-      },
       "VerifyCustomDownloadUrlPayload": {
         "type": "object",
         "properties": {
           "custom_download_url": {
             "description": "Custom external download url with signature and expiration time",
             "type": "string",
-            "format": "uri",
             "example": "https://some-api-url.com?file_id=123&expires_at=1699273500029&signature=abcdefg"
           }
         },
@@ -1345,7 +1517,7 @@
         "properties": {
           "bucket": {
             "type": "string",
-            "example": "epilot-files-prod"
+            "example": "epilot-prod-user-content"
           },
           "key": {
             "type": "string",
@@ -1357,29 +1529,32 @@
           "key"
         ]
       },
+      "S3Ref": {
+        "$ref": "#/components/schemas/S3Reference"
+      },
       "FileItem": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/S3Reference"
+        "type": "object",
+        "properties": {
+          "s3ref": {
+            "$ref": "#/components/schemas/S3Ref"
           },
-          {
-            "type": "object",
-            "properties": {
-              "filename": {
-                "type": "string",
-                "example": "document.pdf"
-              },
-              "size_bytes": {
-                "type": "integer",
-                "example": 1234
-              },
-              "mime_type": {
-                "type": "string",
-                "example": "image/jpeg"
-              }
-            }
+          "filename": {
+            "type": "string",
+            "example": "document.pdf"
+          },
+          "size_bytes": {
+            "type": "integer",
+            "example": 1234
+          },
+          "readable_size": {
+            "type": "string",
+            "example": "1.2 MB"
+          },
+          "mime_type": {
+            "type": "string",
+            "example": "image/jpeg"
           }
-        ]
+        }
       },
       "FileRelationItem": {
         "type": "object",
@@ -1418,6 +1593,91 @@
             "type": "string",
             "description": "The most recent timestamp when the file was accessed"
           }
+        }
+      },
+      "BaseEntityOwner": {
+        "description": "The user / organization owning this entity.\n\nNote: Owner implicitly has access to the entity regardless of ACLs.\n",
+        "type": "object",
+        "properties": {
+          "org_id": {
+            "type": "string",
+            "example": "123"
+          },
+          "user_id": {
+            "type": "string",
+            "example": "123"
+          }
+        },
+        "required": [
+          "org_id"
+        ]
+      },
+      "BaseEntityAcl": {
+        "type": "object",
+        "description": "Access control list (ACL) for an entity. Defines sharing access to external orgs or users.",
+        "properties": {
+          "view": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "org:456"
+            }
+          },
+          "edit": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "org:456"
+            }
+          },
+          "delete": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "example": "org:456"
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
+      "StrictQueryParam": {
+        "name": "strict",
+        "in": "query",
+        "required": false,
+        "description": "When passed true, the response will contain only fields that match the schema, with non-matching fields included in `__additional`",
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "ActivityIdQueryParam": {
+        "name": "activity_id",
+        "description": "Activity to include in event feed",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "$ref": "#/components/schemas/ActivityId"
+        }
+      },
+      "FillActivityQueryParam": {
+        "name": "fill_activity",
+        "description": "Update the diff and entity for the custom activity included in the query.\nPending state on activity is automatically ended when activity is filled.\n",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "AsyncOperationQueryParam": {
+        "name": "async",
+        "description": "Don't wait for updated entity to become available in Search API. Useful for large migrations",
+        "in": "query",
+        "required": false,
+        "schema": {
+          "type": "boolean",
+          "default": false
         }
       }
     }


### PR DESCRIPTION
- Added a `purge` query param to the `/v2/files/:id` API route in `file-client` accessed via `fileClient.deleteFile(...)`
- Updated spec to reflect previous OpenAPI changes introduced 6 months ago