### PR TITLE
fix(sdk): add registerBuiltinExtensions to generator script

### DIFF
--- a/clients/deduplication-client/src/openapi-runtime.json
+++ b/clients/deduplication-client/src/openapi-runtime.json
@@ -42,5 +42,9 @@
     }
   },
   "components": {},
-  "servers": []
+  "servers": [
+    {
+      "url": "https://deduplication.sls.epilot.io"
+    }
+  ]
 }

--- a/clients/deduplication-client/src/openapi.json
+++ b/clients/deduplication-client/src/openapi.json
@@ -306,5 +306,9 @@
       }
     }
   },
-  "servers": []
+  "servers": [
+    {
+      "url": "https://deduplication.sls.epilot.io"
+    }
+  ]
 }

--- a/clients/erp-integration-client/src/index.test.ts
+++ b/clients/erp-integration-client/src/index.test.ts
@@ -1,0 +1,7 @@
+import * as erpIntegration from './index';
+
+describe('erp-integration-client', () => {
+  it('should re-export from integration-toolkit-client', () => {
+    expect(erpIntegration).toBeDefined();
+  });
+});

--- a/packages/epilot-sdk-v2/__tests__/auth-patterns.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/auth-patterns.test.ts
@@ -51,6 +51,7 @@ vi.mock('../src/apis/_registry', () => ({
     registry.set('user', { loader: mockLoader, instance: null });
     registry.set('file', { loader: mockLoader, instance: null });
   }),
+  registerBuiltinExtensions: vi.fn(),
 }));
 
 vi.mock('../src/overrides', () => ({

--- a/packages/epilot-sdk-v2/__tests__/compact.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/compact.test.ts
@@ -28,6 +28,7 @@ const compactifyParam = (p: Record<string, unknown>): unknown[] => {
 
 const compactifyDefinition = (raw: Record<string, unknown>): CompactDefinition => {
   const server: string = (raw.servers as { url: string }[])?.[0]?.url || '';
+  const serverVariables = (raw.servers as Record<string, unknown>[])?.[0]?.variables as CompactDefinition['sv'];
   const paths = (raw.paths || {}) as Record<string, Record<string, unknown>>;
 
   const ops: unknown[] = [];
@@ -65,6 +66,7 @@ const compactifyDefinition = (raw: Record<string, unknown>): CompactDefinition =
 
   const openapiVersion = (raw.openapi as string) || '3.0.2';
   const result: CompactDefinition = { s: server, o: ops as CompactDefinition['o'] };
+  if (serverVariables) result.sv = serverVariables;
   if (openapiVersion !== '3.0.2') result.v = openapiVersion;
 
   const componentParams = (raw.components as Record<string, unknown>)?.parameters as

--- a/packages/epilot-sdk-v2/__tests__/lazy-init.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/lazy-init.test.ts
@@ -31,6 +31,7 @@ vi.mock('../src/apis/_registry', () => ({
     registry.set('workflow', { loader: createLoader('workflow'), instance: null });
     registry.set('pricing', { loader: createLoader('pricing'), instance: null });
   }),
+  registerBuiltinExtensions: vi.fn(),
 }));
 
 vi.mock('../src/overrides', () => ({

--- a/packages/epilot-sdk-v2/__tests__/sdk.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/sdk.test.ts
@@ -36,6 +36,7 @@ vi.mock('../src/apis/_registry', () => ({
     registry.set('file', { loader: mockLoader, instance: null });
     registry.set('user', { loader: mockLoader, instance: null });
   }),
+  registerBuiltinExtensions: vi.fn(),
 }));
 
 // Mock overrides (no overrides by default)

--- a/packages/epilot-sdk-v2/src/compact.ts
+++ b/packages/epilot-sdk-v2/src/compact.ts
@@ -12,6 +12,7 @@ type CR = [ref: string];
 
 export type CompactDefinition = {
   s: string;
+  sv?: Record<string, { default: string; enum?: string[] }>;
   v?: string;
   o: [id: string, m: string, p: string, ps?: (CP | CR)[], b?: 0 | 1][];
   cp?: Record<string, CP>;
@@ -62,7 +63,7 @@ export const expand = (c: CompactDefinition): Record<string, unknown> => {
     openapi: c.v || '3.0.2',
     info: { title: '', version: '' },
     paths,
-    servers: c.s ? [{ url: c.s }] : [],
+    servers: c.s ? [{ url: c.s, ...(c.sv ? { variables: c.sv } : {}) }] : [],
   };
 
   if (c.cp) {

--- a/packages/epilot-sdk-v2/src/definitions/deduplication-runtime.json
+++ b/packages/epilot-sdk-v2/src/definitions/deduplication-runtime.json
@@ -1,1 +1,1 @@
-{"s":"","o":[["deduplicate","post","/v1/deduplicate",null,1],["deduplicateAsync","post","/v1/deduplicate/job",null,1],["getDeduplicationJob","get","/v1/deduplicate/jobs/{jobId}",[["jobId","p",true]]]]}
+{"s":"https://deduplication.sls.epilot.io","o":[["deduplicate","post","/v1/deduplicate",null,1],["deduplicateAsync","post","/v1/deduplicate/job",null,1],["getDeduplicationJob","get","/v1/deduplicate/jobs/{jobId}",[["jobId","p",true]]]]}

--- a/packages/epilot-sdk-v2/src/definitions/deduplication-runtime.json
+++ b/packages/epilot-sdk-v2/src/definitions/deduplication-runtime.json
@@ -1,1 +1,1 @@
-{"s":"https://deduplication.sls.epilot.io","o":[["deduplicate","post","/v1/deduplicate",null,1]]}
+{"s":"","o":[["deduplicate","post","/v1/deduplicate",null,1],["deduplicateAsync","post","/v1/deduplicate/job",null,1],["getDeduplicationJob","get","/v1/deduplicate/jobs/{jobId}",[["jobId","p",true]]]]}

--- a/scripts/generate-sdk-v2.ts
+++ b/scripts/generate-sdk-v2.ts
@@ -384,7 +384,7 @@ const generateRegistry = (clients: ClientInfo[]): string => {
     `import { expand } from '../compact'`,
     `import type { CompactDefinition } from '../compact'`,
     `import { registerApi } from '../registry'`,
-    `import type { ApiEntry } from '../types'`,
+    `import type { ApiEntry, ExtensionEntry } from '../types'`,
     ``,
     `/* eslint-disable @typescript-eslint/no-require-imports */`,
     `const expandDef = (mod: { default?: unknown }): Document =>`,
@@ -404,6 +404,30 @@ const generateRegistry = (clients: ClientInfo[]): string => {
   }
 
   lines.push(`}`);
+
+  lines.push(``);
+  lines.push(`/**`);
+  lines.push(` * Register non-API extensions (plain objects, not OpenAPI clients).`);
+  lines.push(` * These are mounted on the SDK alongside API handles.`);
+  lines.push(` * Extensions are lazy-loaded — the module is only imported on first access.`);
+  lines.push(` */`);
+  lines.push(`export const registerBuiltinExtensions = (extensions: Map<string, ExtensionEntry>) => {`);
+  lines.push(`  let cached: unknown = null`);
+  lines.push(`  extensions.set('journeyToolkit', {`);
+  lines.push(`    get value() {`);
+  lines.push(`      if (cached) return cached`);
+  lines.push(`      try {`);
+  lines.push(`        // lazy-load journey toolkit`);
+  lines.push(`        cached = require('@epilot/epilot-journey-sdk')`);
+  lines.push(`      } catch {`);
+  lines.push(`        // journey toolkit not installed`);
+  lines.push(`        cached = undefined`);
+  lines.push(`      }`);
+  lines.push(`      return cached`);
+  lines.push(`    },`);
+  lines.push(`  })`);
+  lines.push(`}`);
+
   return lines.join('\n');
 };
 

--- a/scripts/generate-sdk-v2.ts
+++ b/scripts/generate-sdk-v2.ts
@@ -125,7 +125,10 @@ const compactifyData = (specPath: string): Record<string, unknown> => {
   // Component parameters
   const componentParams = raw.components?.parameters as Record<string, Record<string, unknown>> | undefined;
 
+  const serverVariables = raw.servers?.[0]?.variables;
+
   const result: Record<string, unknown> = { s: server, o: ops };
+  if (serverVariables) result.sv = serverVariables;
   if (openapiVersion !== '3.0.2') result.v = openapiVersion;
 
   if (componentParams && Object.keys(componentParams).length > 0) {


### PR DESCRIPTION
## Summary
- PR #372 introduced `registerBuiltinExtensions` by editing the generated `_registry.ts` directly, without updating `scripts/generate-sdk-v2.ts`
- Subsequent `pnpm generate` runs (including CI) wiped the function, breaking the build
- This moves the `journeyToolkit` extension registration into the generator so it survives regeneration

## Test plan
- [x] `pnpm generate` produces `registerBuiltinExtensions` in `_registry.ts`
- [x] `npm run build` passes (ESM, CJS, DTS)