### PR TITLE
fix: handle CJS/ESM interop for openapi-client-axios default export

### DIFF
--- a/packages/epilot-sdk-v2/src/client-factory.ts
+++ b/packages/epilot-sdk-v2/src/client-factory.ts
@@ -1,10 +1,17 @@
 import type { AxiosInstance } from 'axios';
 import type { Document } from 'openapi-client-axios';
-import OpenAPIClientAxios from 'openapi-client-axios';
+import _OpenAPIClientAxios from 'openapi-client-axios';
 
 import { authorize, type TokenArg } from './authorize';
 import { help as helpFn } from './help';
 import { openapi as openapiFn } from './openapi';
+
+// Handle CJS/ESM interop — when bundled as CJS, the default export may be nested under .default
+const OpenAPIClientAxios = (
+  typeof (_OpenAPIClientAxios as any).default === 'function'
+    ? (_OpenAPIClientAxios as any).default
+    : _OpenAPIClientAxios
+) as typeof _OpenAPIClientAxios;
 
 export const createApiClient = <T extends AxiosInstance = AxiosInstance>(params: {
   definition: Document;


### PR DESCRIPTION
When the SDK is bundled with esbuild in CJS mode (e.g., Lambda), the default export of openapi-client-axios may be nested under .default. This adds a runtime check to resolve it correctly in both cases.