### PR TITLE
feat(cli): add --use-dev and --use-staging flags

### DIFF
--- a/packages/cli/bin/epilot.ts
+++ b/packages/cli/bin/epilot.ts
@@ -93,6 +93,8 @@ function printRootHelp() {
   w(`  ${GREEN}-t, --token${R} <token>     Bearer token for authentication\n`);
   w(`  ${GREEN}--profile${R} <name>        Use a named profile ${DIM}(or EPILOT_PROFILE)${R}\n`);
   w(`  ${GREEN}-s, --server${R} <url>      Override server base URL\n`);
+  w(`  ${GREEN}--use-dev${R}               Target dev environment\n`);
+  w(`  ${GREEN}--use-staging${R}            Target staging environment\n`);
   w(`  ${GREEN}--json${R}                  Output raw JSON (no formatting)\n`);
   w(`  ${GREEN}-v, --verbose${R}           Verbose output (show request details)\n`);
   w(`  ${GREEN}--jsonata${R} <expr>        JSONata expression to transform response\n`);
@@ -111,6 +113,7 @@ function printRootHelp() {
   w(`  ${CYAN}auth status${R}             Show authentication status\n`);
   w(`  ${CYAN}auth logout${R}             Remove stored credentials\n`);
   w(`  ${CYAN}profile${R}                 Manage named profiles\n`);
+  w(`  ${CYAN}config${R}                  Manage CLI configuration\n`);
   w(`  ${CYAN}completion${R}              Generate shell completion scripts\n`);
   w(`  ${CYAN}upgrade${R}                 Upgrade to the latest version\n`);
   w(`\n`);
@@ -131,6 +134,8 @@ function printRootHelp() {
   w(`  ${YELLOW}$${R} epilot entity searchEntities -d '{"q":"*"}'\n`);
   w(`  ${YELLOW}$${R} epilot entity searchEntities --jsonata 'results[0]._title'\n`);
   w(`  ${YELLOW}$${R} echo '{"q":"*"}' | epilot entity searchEntities\n`);
+  w(`  ${YELLOW}$${R} epilot entity searchEntities --use-dev ${DIM}# target dev environment${R}\n`);
+  w(`  ${YELLOW}$${R} epilot config set stage dev ${DIM}# persist dev as default${R}\n`);
   w(`\n`);
   w(`Run ${CYAN}epilot <api>${R} to list available operations.\n`);
   w(`Run ${CYAN}epilot <api> <operationId> --help${R} for operation details.\n`);

--- a/packages/cli/scripts/generate.ts
+++ b/packages/cli/scripts/generate.ts
@@ -364,6 +364,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },
@@ -426,6 +428,8 @@ export const main = defineCommand({
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     profile: { type: 'string', description: 'Use a named profile (or EPILOT_PROFILE env)' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     json: { type: 'boolean', description: 'Output raw JSON' },
     verbose: { type: 'boolean', alias: 'v', description: 'Verbose output' },
     guided: { type: 'boolean', description: 'Prompt for all parameters interactively' },
@@ -435,6 +439,7 @@ export const main = defineCommand({
   subCommands: {
     auth: () => import('./commands/auth.js').then((m) => m.default),
     profile: () => import('./commands/profile.js').then((m) => m.default),
+    config: () => import('./commands/config.js').then((m) => m.default),
     completion: () => import('./commands/completion.js').then((m) => m.default),
     upgrade: () => import('./commands/upgrade.js').then((m) => m.default),
 ${subCommandEntries.join('\n')}

--- a/packages/cli/src/commands/apis/access-token.ts
+++ b/packages/cli/src/commands/apis/access-token.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/address-suggestions.ts
+++ b/packages/cli/src/commands/apis/address-suggestions.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/address.ts
+++ b/packages/cli/src/commands/apis/address.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/ai-agents.ts
+++ b/packages/cli/src/commands/apis/ai-agents.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/audit-logs.ts
+++ b/packages/cli/src/commands/apis/audit-logs.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/automation.ts
+++ b/packages/cli/src/commands/apis/automation.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/billing.ts
+++ b/packages/cli/src/commands/apis/billing.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/blueprint-manifest.ts
+++ b/packages/cli/src/commands/apis/blueprint-manifest.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/configuration-hub.ts
+++ b/packages/cli/src/commands/apis/configuration-hub.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/consent.ts
+++ b/packages/cli/src/commands/apis/consent.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/customer-portal.ts
+++ b/packages/cli/src/commands/apis/customer-portal.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/dashboard.ts
+++ b/packages/cli/src/commands/apis/dashboard.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/data-governance.ts
+++ b/packages/cli/src/commands/apis/data-governance.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/deduplication.ts
+++ b/packages/cli/src/commands/apis/deduplication.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/design.ts
+++ b/packages/cli/src/commands/apis/design.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/document.ts
+++ b/packages/cli/src/commands/apis/document.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/email-settings.ts
+++ b/packages/cli/src/commands/apis/email-settings.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/email-template.ts
+++ b/packages/cli/src/commands/apis/email-template.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/entity-mapping.ts
+++ b/packages/cli/src/commands/apis/entity-mapping.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/entity.ts
+++ b/packages/cli/src/commands/apis/entity.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/environments.ts
+++ b/packages/cli/src/commands/apis/environments.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/event-catalog.ts
+++ b/packages/cli/src/commands/apis/event-catalog.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/file.ts
+++ b/packages/cli/src/commands/apis/file.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/iban.ts
+++ b/packages/cli/src/commands/apis/iban.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/integration-toolkit.ts
+++ b/packages/cli/src/commands/apis/integration-toolkit.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/journey.ts
+++ b/packages/cli/src/commands/apis/journey.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/kanban.ts
+++ b/packages/cli/src/commands/apis/kanban.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/message.ts
+++ b/packages/cli/src/commands/apis/message.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/metering.ts
+++ b/packages/cli/src/commands/apis/metering.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/notes.ts
+++ b/packages/cli/src/commands/apis/notes.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/notification.ts
+++ b/packages/cli/src/commands/apis/notification.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/organization.ts
+++ b/packages/cli/src/commands/apis/organization.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/partner-directory.ts
+++ b/packages/cli/src/commands/apis/partner-directory.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/permissions.ts
+++ b/packages/cli/src/commands/apis/permissions.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/pricing-tier.ts
+++ b/packages/cli/src/commands/apis/pricing-tier.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/pricing.ts
+++ b/packages/cli/src/commands/apis/pricing.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/purpose.ts
+++ b/packages/cli/src/commands/apis/purpose.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/query.ts
+++ b/packages/cli/src/commands/apis/query.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/sandbox.ts
+++ b/packages/cli/src/commands/apis/sandbox.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/sharing.ts
+++ b/packages/cli/src/commands/apis/sharing.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/submission.ts
+++ b/packages/cli/src/commands/apis/submission.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/targeting.ts
+++ b/packages/cli/src/commands/apis/targeting.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/template-variables.ts
+++ b/packages/cli/src/commands/apis/template-variables.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/user.ts
+++ b/packages/cli/src/commands/apis/user.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/validation-rules.ts
+++ b/packages/cli/src/commands/apis/validation-rules.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/webhooks.ts
+++ b/packages/cli/src/commands/apis/webhooks.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/workflow-definition.ts
+++ b/packages/cli/src/commands/apis/workflow-definition.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/apis/workflow.ts
+++ b/packages/cli/src/commands/apis/workflow.ts
@@ -12,6 +12,8 @@ export default defineCommand({
     include: { type: 'boolean', alias: 'i', description: 'Include response headers' },
     definition: { type: 'string', description: 'Override OpenAPI spec file/URL' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     profile: { type: 'string', description: 'Use a named profile' },
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     json: { type: 'boolean', description: 'Output raw JSON' },

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,0 +1,67 @@
+import { defineCommand } from 'citty';
+import { getStage, setStage } from '../lib/profiles.js';
+import { BOLD, RESET, GREEN, RED, DIM, YELLOW } from '../lib/utils.js';
+
+const VALID_STAGES = ['prod', 'dev', 'staging'] as const;
+
+const CONFIG_KEYS = {
+  stage: {
+    get: () => getStage() ?? 'prod',
+    set: (value: string) => {
+      if (!VALID_STAGES.includes(value as (typeof VALID_STAGES)[number])) {
+        process.stderr.write(`${RED}Invalid stage "${value}". Must be one of: ${VALID_STAGES.join(', ')}${RESET}\n`);
+        process.exit(1);
+      }
+      setStage(value === 'prod' ? undefined : value);
+    },
+  },
+} as const;
+
+export default defineCommand({
+  meta: {
+    name: 'config',
+    description: 'Manage CLI configuration',
+  },
+  subCommands: {
+    get: defineCommand({
+      meta: { name: 'get', description: 'Get a config value' },
+      args: {
+        key: { type: 'positional', description: 'Config key', required: true },
+      },
+      run: ({ args }) => {
+        const handler = CONFIG_KEYS[args.key as keyof typeof CONFIG_KEYS];
+        if (!handler) {
+          process.stderr.write(`${RED}Unknown config key "${args.key}".${RESET}\n`);
+          process.stderr.write(`Available keys: ${Object.keys(CONFIG_KEYS).join(', ')}\n`);
+          process.exit(1);
+        }
+        process.stdout.write(`${handler.get()}\n`);
+      },
+    }),
+
+    set: defineCommand({
+      meta: { name: 'set', description: 'Set a config value' },
+      args: {
+        key: { type: 'positional', description: 'Config key', required: true },
+        value: { type: 'positional', description: 'Config value', required: true },
+      },
+      run: ({ args }) => {
+        const handler = CONFIG_KEYS[args.key as keyof typeof CONFIG_KEYS];
+        if (!handler) {
+          process.stderr.write(`${RED}Unknown config key "${args.key}".${RESET}\n`);
+          process.stderr.write(`Available keys: ${Object.keys(CONFIG_KEYS).join(', ')}\n`);
+          process.exit(1);
+        }
+        handler.set(args.value);
+        process.stdout.write(`${GREEN}Set ${BOLD}${args.key}${RESET}${GREEN} = ${args.value}${RESET}\n`);
+      },
+    }),
+
+    list: defineCommand({
+      meta: { name: 'list', description: 'List all config values' },
+      run: () => {
+        process.stdout.write(`${BOLD}stage${RESET}  ${DIM}=${RESET}  ${getStage() ?? 'prod'}  ${DIM}(${YELLOW}prod${DIM} | dev | staging)${RESET}\n`);
+      },
+    }),
+  },
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,8 @@ export const main = defineCommand({
     token: { type: 'string', alias: 't', description: 'Bearer token' },
     profile: { type: 'string', description: 'Use a named profile (or EPILOT_PROFILE env)' },
     server: { type: 'string', alias: 's', description: 'Override server base URL' },
+    'use-dev': { type: 'boolean', description: 'Target dev environment' },
+    'use-staging': { type: 'boolean', description: 'Target staging environment' },
     json: { type: 'boolean', description: 'Output raw JSON' },
     verbose: { type: 'boolean', alias: 'v', description: 'Verbose output' },
     guided: { type: 'boolean', description: 'Prompt for all parameters interactively' },
@@ -19,6 +21,7 @@ export const main = defineCommand({
   subCommands: {
     auth: () => import('./commands/auth.js').then((m) => m.default),
     profile: () => import('./commands/profile.js').then((m) => m.default),
+    config: () => import('./commands/config.js').then((m) => m.default),
     completion: () => import('./commands/completion.js').then((m) => m.default),
     upgrade: () => import('./commands/upgrade.js').then((m) => m.default),
     'access-token': () => import('./commands/apis/access-token.js').then((m) => m.default),

--- a/packages/cli/src/lib/call.ts
+++ b/packages/cli/src/lib/call.ts
@@ -8,7 +8,7 @@ const OpenAPIClientAxios =
 
 import { loadDefinition } from './definition-loader.js';
 import { resolveToken } from './auth-store.js';
-import { getResolvedProfile } from './profiles.js';
+import { getResolvedProfile, getStage } from './profiles.js';
 import { collectParams, getOperationParams, getMissingRequired } from './param-collector.js';
 import { resolveBody, getRequestBodyInfo } from './body-handler.js';
 import { formatResponse } from './response-formatter.js';
@@ -34,6 +34,27 @@ export type CallArgs = {
   guided?: boolean;
   help?: boolean;
   _apihelp?: boolean;
+  'use-dev'?: boolean;
+  'use-staging'?: boolean;
+};
+
+/**
+ * Rewrite a production URL to target a different stage.
+ * e.g. https://entity.sls.epilot.io → https://entity.dev.sls.epilot.io
+ */
+const toStageUrl = (prodUrl: string, stage: string): string => {
+  if (stage === 'prod') return prodUrl;
+  return prodUrl.replace('.sls.epilot.io', `.${stage}.sls.epilot.io`);
+};
+
+/**
+ * Resolve the target stage from flags and profile config.
+ * Priority: --use-dev/--use-staging flags > saved config > 'prod'
+ */
+const resolveStage = (args: CallArgs): string => {
+  if (args['use-dev']) return 'dev';
+  if (args['use-staging']) return 'staging';
+  return getStage() ?? 'prod';
 };
 
 /**
@@ -206,6 +227,8 @@ const formatOperationHelp = (apiName: string, operationId: string, spec: OpenAPI
       w(`  ${GREEN}-t, --token${RESET} <token>     Bearer token for authentication\n`);
       w(`  ${GREEN}--profile${RESET} <name>        Use a named profile\n`);
       w(`  ${GREEN}-s, --server${RESET} <url>      Override server base URL\n`);
+      w(`  ${GREEN}--use-dev${RESET}               Target dev environment\n`);
+      w(`  ${GREEN}--use-staging${RESET}            Target staging environment\n`);
       w(`  ${GREEN}-i, --include${RESET}           Include response headers in output\n`);
       w(`  ${GREEN}--json${RESET}                  Output raw JSON (no formatting)\n`);
       w(`  ${GREEN}-v, --verbose${RESET}           Verbose output (show request details)\n`);
@@ -483,11 +506,19 @@ export const callApi = async (apiName: string, args: CallArgs): Promise<void> =>
     }
   }
 
-  // Resolve server URL override: --server flag > profile > spec default
+  // Resolve server URL: --server flag > profile server > stage-rewritten spec default
   const serverOverride = args.server || getResolvedProfile(args.profile)?.server;
   if (serverOverride) {
     const specDoc = spec as OpenAPIV3.Document;
     specDoc.servers = [{ url: serverOverride }];
+  } else {
+    const stage = resolveStage(args);
+    if (stage !== 'prod') {
+      const specDoc = spec as OpenAPIV3.Document;
+      if (specDoc.servers?.length) {
+        specDoc.servers = specDoc.servers.map((s) => ({ ...s, url: toStageUrl(s.url, stage) }));
+      }
+    }
   }
 
   // Init OpenAPI client

--- a/packages/cli/src/lib/profiles.ts
+++ b/packages/cli/src/lib/profiles.ts
@@ -24,6 +24,8 @@ export type ProfileConfig = {
   active?: string;
   /** Named profiles */
   profiles: Record<string, Profile>;
+  /** Global stage preference: 'prod' | 'dev' | 'staging' */
+  stage?: string;
 };
 
 const getConfigDir = (): string => {
@@ -103,6 +105,17 @@ export const deleteProfile = (name: string): boolean => {
   if (config.active === name) config.active = undefined;
   saveProfiles(config);
   return true;
+};
+
+export const getStage = (): string | undefined => {
+  const config = loadProfiles();
+  return config.stage;
+};
+
+export const setStage = (stage: string | undefined): void => {
+  const config = loadProfiles();
+  config.stage = stage;
+  saveProfiles(config);
 };
 
 export const listProfiles = (): { name: string; profile: Profile; active: boolean }[] => {


### PR DESCRIPTION
## Summary
- Add --use-dev and --use-staging flags to all CLI commands that rewrite API base URLs (e.g. entity.sls.epilot.io to entity.dev.sls.epilot.io)
- Add epilot config set stage dev|staging|prod to persist stage preference
- Add epilot config get stage and epilot config list to check settings
- Priority: --server > --use-dev/--use-staging > saved config > prod default

## Test plan
- [x] epilot entity searchEntities --use-dev --verbose shows entity.dev.sls.epilot.io
- [x] epilot entity searchEntities --use-staging --verbose shows entity.staging.sls.epilot.io
- [x] epilot config set stage dev persists and applies to subsequent calls
- [x] --use-staging overrides saved dev config
- [x] --server overrides both flags and config
- [x] epilot config set stage invalid shows error with valid options
- [x] epilot --help shows new flags, config command, and examples