### PR TITLE
fix(cli): add --use-dev and --use-staging flags to auth login

### DIFF
--- a/packages/cli/src/commands/auth-login.ts
+++ b/packages/cli/src/commands/auth-login.ts
@@ -2,6 +2,7 @@ import { defineCommand } from 'citty';
 import { randomBytes } from 'node:crypto';
 import { createServer } from 'node:http';
 import { saveCredentials } from '../lib/auth-store.js';
+import { type Environment, getPortalUrl, resolveEnvironment } from '../lib/environment.js';
 import { BOLD, RESET, GREEN, RED, DIM, YELLOW, CYAN } from '../lib/utils.js';
 
 export default defineCommand({
@@ -9,9 +10,12 @@ export default defineCommand({
   args: {
     token: { type: 'string', description: 'Manually provide a token instead of browser login' },
     profile: { type: 'string', description: 'Save credentials to this profile' },
+    'use-dev': { type: 'boolean', description: 'Use dev environment (portal.dev.epilot.cloud)' },
+    'use-staging': { type: 'boolean', description: 'Use staging environment (portal.staging.epilot.cloud)' },
   },
   run: async ({ args }) => {
     const profileName = args.profile || process.env.EPILOT_PROFILE;
+    const env = resolveEnvironment(args['use-dev'], args['use-staging']);
 
     // Manual token input
     if (args.token) {
@@ -29,7 +33,7 @@ export default defineCommand({
       process.exit(1);
     }
 
-    const token = await browserLogin(profileName);
+    const token = await browserLogin(profileName, env);
     if (token) {
       process.stdout.write(`${GREEN}${BOLD}Login successful!${RESET}\n`);
     } else {
@@ -39,7 +43,7 @@ export default defineCommand({
   },
 });
 
-const browserLogin = async (profileName?: string): Promise<string | null> => {
+const browserLogin = async (profileName?: string, env: Environment = 'production'): Promise<string | null> => {
   // Generate a cryptographic state parameter to prevent CSRF
   const state = randomBytes(32).toString('hex');
 
@@ -91,8 +95,9 @@ const browserLogin = async (profileName?: string): Promise<string | null> => {
 
       const port = address.port;
       const callbackUrl = `http://localhost:${port}/callback`;
+      const portalUrl = getPortalUrl(env);
       const loginUrl =
-        `https://portal.epilot.cloud/login?cli_callback=${encodeURIComponent(callbackUrl)}` +
+        `${portalUrl}/login?cli_callback=${encodeURIComponent(callbackUrl)}` +
         `&state=${state}` +
         `&code=${verificationCode}`;
 

--- a/packages/cli/src/lib/environment.ts
+++ b/packages/cli/src/lib/environment.ts
@@ -1,0 +1,17 @@
+export type Environment = 'production' | 'staging' | 'dev';
+
+export const PORTAL_URLS: Record<Environment, string> = {
+  production: 'https://portal.epilot.cloud',
+  staging: 'https://portal.staging.epilot.cloud',
+  dev: 'https://portal.dev.epilot.cloud',
+};
+
+export const getPortalUrl = (env: Environment = 'production'): string => {
+  return PORTAL_URLS[env];
+};
+
+export const resolveEnvironment = (useDev?: boolean, useStaging?: boolean): Environment => {
+  if (useDev) return 'dev';
+  if (useStaging) return 'staging';
+  return 'production';
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1426,13 +1426,13 @@ importers:
         version: 7.8.0(encoding@0.1.13)(js-yaml@4.1.1)
       openapicmd:
         specifier: ^2.9.2
-        version: 2.9.2(@types/node@24.2.0)(encoding@0.1.13)(node-notifier@8.0.2)(openapi-types@12.1.3)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+        version: 2.9.2(@types/node@24.2.0)(encoding@0.1.13)(node-notifier@8.0.2)(openapi-types@12.1.3)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       ts-loader:
         specifier: ^8.3.0
-        version: 8.4.0(typescript@5.9.3)(webpack@5.105.4)
+        version: 8.4.0(typescript@5.7.3)(webpack@5.105.4)
       typescript:
         specifier: ^5.4.5
-        version: 5.9.3
+        version: 5.7.3
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@24.2.0)(jsdom@26.1.0)(terser@5.46.0)
@@ -2417,10 +2417,10 @@ importers:
         version: 7.8.0(encoding@0.1.13)(js-yaml@4.1.1)
       ts-loader:
         specifier: ^8.3.0
-        version: 8.4.0(typescript@5.9.3)(webpack@5.105.4)
+        version: 8.4.0(typescript@5.7.3)(webpack@5.105.4)
       typescript:
         specifier: ^5.4.5
-        version: 5.9.3
+        version: 5.7.3
       vitest:
         specifier: ^1.6.0
         version: 1.6.1(@types/node@24.2.0)(jsdom@26.1.0)(terser@5.46.0)
@@ -2678,16 +2678,16 @@ importers:
     devDependencies:
       msw:
         specifier: ^2.12.10
-        version: 2.12.10(@types/node@24.2.0)(typescript@5.9.3)
+        version: 2.12.10(@types/node@24.2.0)(typescript@5.7.3)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
       typescript:
         specifier: ^5.3.0
-        version: 5.9.3
+        version: 5.7.3
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@24.2.0)(jsdom@26.1.0)(terser@5.46.0)
@@ -2695,36 +2695,36 @@ importers:
   packages/cli-wrapper:
     dependencies:
       '@epilot/cli':
-        specifier: ^0.1.17
-        version: 0.1.17(@types/node@24.2.0)(js-yaml@4.1.1)
+        specifier: ^0.1.18
+        version: 0.1.18(@types/node@24.2.0)(js-yaml@4.1.1)
 
   packages/epilot-sdk-v2:
-    optionalDependencies:
-      '@epilot/epilot-journey-sdk':
-        specifier: '>=2.0.0-alpha.1'
-        version: 2.0.0-alpha.1(@material-ui/core@4.12.4(@types/react@17.0.91)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(axios@1.13.6)(js-yaml@4.1.1)
     devDependencies:
       axios:
         specifier: ^1.11.0
         version: 1.13.6(debug@4.4.1)
       msw:
         specifier: ^2.10.4
-        version: 2.12.10(@types/node@24.2.0)(typescript@5.9.3)
+        version: 2.12.10(@types/node@24.2.0)(typescript@5.7.3)
       openapi-client-axios:
         specifier: ^7.8.0
         version: 7.9.0(axios@1.13.6)(js-yaml@4.1.1)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
       typescript:
         specifier: ^5.3.0
-        version: 5.9.3
+        version: 5.7.3
       vitest:
         specifier: ^1.0.0
         version: 1.6.1(@types/node@24.2.0)(jsdom@26.1.0)(terser@5.46.0)
+    optionalDependencies:
+      '@epilot/epilot-journey-sdk':
+        specifier: '>=2.0.0-alpha.1'
+        version: 2.0.0-alpha.1(@material-ui/core@4.12.4(@types/react@17.0.91)(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(axios@1.13.6)(js-yaml@4.1.1)
 
 packages:
 
@@ -3082,8 +3082,8 @@ packages:
   '@emotion/hash@0.8.0':
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
 
-  '@epilot/cli@0.1.17':
-    resolution: {integrity: sha512-x1R5lq7GKmCz8dmA36mexLMqF/vzWPkIBs2dGpihEr8urJ4q4ybhW1Utsy/JsWd1X5Q5GFZa+OIDbejKtg69WA==}
+  '@epilot/cli@0.1.18':
+    resolution: {integrity: sha512-ETDdkRCBwGf+tiy9WHR127Yfza43HSCrUICZWc4Bc3C2Z2Na9U25FO9D37AsrqaARKnDjDI1FqTTS9qSnzro+Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7243,11 +7243,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -8180,7 +8175,7 @@ snapshots:
   '@emotion/hash@0.8.0':
     optional: true
 
-  '@epilot/cli@0.1.17(@types/node@24.2.0)(js-yaml@4.1.1)':
+  '@epilot/cli@0.1.18(@types/node@24.2.0)(js-yaml@4.1.1)':
     dependencies:
       '@inquirer/prompts': 7.10.1(@types/node@24.2.0)
       axios: 1.13.6(debug@4.4.1)
@@ -8644,7 +8639,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))':
+  '@jest/core@29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0(node-notifier@8.0.2)
@@ -8658,7 +8653,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -10124,13 +10119,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -11070,16 +11065,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -11143,7 +11138,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@24.2.0)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3)):
     dependencies:
       '@babel/core': 7.28.0
       '@jest/test-sequencer': 29.7.0
@@ -11169,7 +11164,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 24.2.0
-      ts-node: 10.9.2(@types/node@24.2.0)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@24.2.0)(typescript@5.7.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -11494,12 +11489,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      '@jest/core': 29.7.0(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -11905,31 +11900,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  msw@2.12.10(@types/node@24.2.0)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@24.2.0)
-      '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.0.2
-      graphql: 16.13.1
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.10.1
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.0
-      type-fest: 5.4.4
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-
   mute-stream@0.0.8: {}
 
   mute-stream@2.0.0: {}
@@ -12164,7 +12134,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  openapicmd@2.9.2(@types/node@24.2.0)(encoding@0.1.13)(node-notifier@8.0.2)(openapi-types@12.1.3)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3)):
+  openapicmd@2.9.2(@types/node@24.2.0)(encoding@0.1.13)(node-notifier@8.0.2)(openapi-types@12.1.3)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3)):
     dependencies:
       '@anttiviljami/dtsgenerator': 3.20.0(encoding@0.1.13)
       '@apidevtools/swagger-parser': 10.1.1(openapi-types@12.1.3)
@@ -12185,7 +12155,7 @@ snapshots:
       deepmerge: 4.3.1
       get-port: 5.1.1
       inquirer: 7.3.3
-      jest: 29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@24.2.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3))
       jest-json-schema: 6.1.0
       js-yaml: 4.1.1
       klona: 2.0.6
@@ -13041,16 +13011,6 @@ snapshots:
       typescript: 5.7.3
       webpack: 5.105.4(webpack-cli@5.1.4)
 
-  ts-loader@8.4.0(typescript@5.9.3)(webpack@5.105.4):
-    dependencies:
-      chalk: 4.1.2
-      enhanced-resolve: 4.5.0
-      loader-utils: 2.0.4
-      micromatch: 4.0.8
-      semver: 7.7.2
-      typescript: 5.9.3
-      webpack: 5.105.4(webpack-cli@5.1.4)
-
   ts-node@10.9.2(@types/node@24.2.0)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -13070,7 +13030,7 @@ snapshots:
       yn: 3.1.1
     optional: true
 
-  ts-node@10.9.2(@types/node@24.2.0)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@24.2.0)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -13084,7 +13044,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -13113,7 +13073,7 @@ snapshots:
 
   tsscmp@1.0.6: {}
 
-  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.6)(tsx@4.21.0)(typescript@5.7.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -13134,7 +13094,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       postcss: 8.5.6
-      typescript: 5.9.3
+      typescript: 5.7.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -13166,8 +13126,6 @@ snapshots:
   typescript@4.9.5: {}
 
   typescript@5.7.3: {}
-
-  typescript@5.9.3: {}
 
   ufo@1.6.1: {}
 


### PR DESCRIPTION
The `epilot auth login` command now supports environment-specific portal URLs:
- `--use-dev`: Uses portal.dev.epilot.cloud
- `--use-staging`: Uses portal.staging.epilot.cloud
- Default (no flag): Uses portal.epilot.cloud

Slack thread: https://epilot.slack.com/archives/C0ADDKKTLVD/p1776410443934619

https://claude.ai/code/session_0153bVhdxpi6uPcDjhQTgxKm