### PR TITLE
fix: allow global flags (--use-dev, --server, --json, etc.) to be passed anywhere in the command, not just after the operationId

### DIFF
--- a/packages/cli/bin/epilot.ts
+++ b/packages/cli/bin/epilot.ts
@@ -1,6 +1,7 @@
 import { runMain } from 'citty';
 import { main } from '../src/index.js';
 import { API_LIST } from '../src/generated/api-list.js';
+import { hoistFlagsAfterSubcommand } from '../src/lib/reorder-args.js';
 
 // Gracefully handle EPIPE (e.g. piping to `head` or `jq` that closes early)
 process.stdout.on('error', (err) => {
@@ -19,6 +20,12 @@ const VERSION =
     ? __CLI_VERSION__
     : ((await import('../package.json', { with: { type: 'json' } })) as { default: { version: string } }).default
         .version;
+
+// Reorder argv so global flags (e.g. --use-dev, --json, --server) can be
+// passed before the subcommand. Without this, citty strips leading flags
+// when dispatching to the subcommand.
+const reorderedArgv = hoistFlagsAfterSubcommand(process.argv.slice(2));
+process.argv = [process.argv[0], process.argv[1], ...reorderedArgv];
 
 const args = process.argv.slice(2);
 

--- a/packages/cli/src/lib/reorder-args.ts
+++ b/packages/cli/src/lib/reorder-args.ts
@@ -1,0 +1,92 @@
+/**
+ * Reorders CLI args so that global flags passed BEFORE the subcommand are
+ * moved to AFTER the subcommand (and its operationId, when applicable).
+ *
+ * Motivation: citty dispatches subcommands using `rawArgs.slice(subCommandIdx + 1)`,
+ * which drops any leading flags. That means `epilot --use-dev entity listTaxonomies`
+ * never passes `--use-dev` to the `entity` subcommand. By hoisting those leading
+ * flags to a position the subcommand will see, all of these become equivalent:
+ *
+ *   epilot --use-dev --json entity listTaxonomies
+ *   epilot entity --use-dev --json listTaxonomies
+ *   epilot entity listTaxonomies --use-dev --json
+ *
+ * The reorder is intentionally narrow: it only moves leading flags, preserves
+ * relative order, and leaves the subcommand name and its positional args in place.
+ */
+
+/**
+ * Global flags that take a value (consume the next token).
+ * Used to decide whether a leading `--flag` should swallow the next arg.
+ */
+const VALUE_TAKING_FLAGS = new Set([
+  // long
+  '--token',
+  '--profile',
+  '--server',
+  '--jsonata',
+  '--definition',
+  // short
+  '-t',
+  '-s',
+]);
+
+/**
+ * Returns true if the token looks like a flag (starts with `-` but is not
+ * just `-` or `--`).
+ */
+const isFlag = (token: string): boolean => {
+  if (token === '-' || token === '--') return false;
+  return token.startsWith('-');
+};
+
+/**
+ * Given a flag token, returns true if it expects a separate value token.
+ * Handles both `--server` and `--server=value` forms (the latter does NOT
+ * consume a separate token).
+ */
+const consumesNextToken = (token: string): boolean => {
+  if (token.includes('=')) return false;
+  return VALUE_TAKING_FLAGS.has(token);
+};
+
+/**
+ * Reorder argv so global flags appearing before the first positional (i.e.
+ * the subcommand) are moved to immediately after that positional.
+ *
+ * Unknown subcommand names are still treated as "first positional"; citty
+ * will handle the unknown-subcommand error itself.
+ *
+ * @param argv - argv WITHOUT the node+script prefix (i.e. `process.argv.slice(2)`)
+ * @returns a new array; never mutates the input
+ */
+export const hoistFlagsAfterSubcommand = (argv: string[]): string[] => {
+  // Find the first positional token, honoring value-taking flags so we don't
+  // mistake a flag's argument for the subcommand name.
+  let firstPositionalIdx = -1;
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (isFlag(token)) {
+      if (consumesNextToken(token)) i += 1; // skip the value
+      continue;
+    }
+    // `--` ends option parsing; anything after is positional but we treat it as a boundary
+    if (token === '--') break;
+    firstPositionalIdx = i;
+    break;
+  }
+
+  // No positional found, or it's already at position 0 — nothing to reorder.
+  if (firstPositionalIdx <= 0) return argv.slice();
+
+  const leading = argv.slice(0, firstPositionalIdx);
+  const subcommand = argv[firstPositionalIdx];
+  const rest = argv.slice(firstPositionalIdx + 1);
+
+  // Place the subcommand first, then any trailing tokens (which may contain
+  // the operationId and its own flags), then the hoisted leading flags.
+  // Placing hoisted flags at the end keeps the operationId in position 0 of
+  // the subcommand's rawArgs, which is what the generated API commands and
+  // downstream positional-arg extraction both expect.
+  return [subcommand, ...rest, ...leading];
+};

--- a/packages/cli/test/reorder-args.test.ts
+++ b/packages/cli/test/reorder-args.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { hoistFlagsAfterSubcommand } from '../src/lib/reorder-args.js';
+
+describe('hoistFlagsAfterSubcommand', () => {
+  describe('no reordering needed', () => {
+    it('returns empty array unchanged', () => {
+      expect(hoistFlagsAfterSubcommand([])).toEqual([]);
+    });
+
+    it('returns flag-only argv unchanged', () => {
+      expect(hoistFlagsAfterSubcommand(['--help'])).toEqual(['--help']);
+      expect(hoistFlagsAfterSubcommand(['--version'])).toEqual(['--version']);
+      expect(hoistFlagsAfterSubcommand(['--use-dev', '--json'])).toEqual(['--use-dev', '--json']);
+    });
+
+    it('leaves flags placed after the subcommand alone', () => {
+      expect(hoistFlagsAfterSubcommand(['entity', 'listTaxonomies', '--use-dev', '--json'])).toEqual([
+        'entity',
+        'listTaxonomies',
+        '--use-dev',
+        '--json',
+      ]);
+    });
+
+    it('leaves flags between subcommand and operation alone', () => {
+      expect(hoistFlagsAfterSubcommand(['entity', '--use-dev', 'listTaxonomies'])).toEqual([
+        'entity',
+        '--use-dev',
+        'listTaxonomies',
+      ]);
+    });
+
+    it('does not reorder when subcommand is first', () => {
+      expect(hoistFlagsAfterSubcommand(['auth', 'login'])).toEqual(['auth', 'login']);
+    });
+  });
+
+  describe('hoisting leading boolean flags', () => {
+    it('moves a single leading boolean flag to after the subcommand', () => {
+      expect(hoistFlagsAfterSubcommand(['--use-dev', 'entity', 'listTaxonomies'])).toEqual([
+        'entity',
+        'listTaxonomies',
+        '--use-dev',
+      ]);
+    });
+
+    it('moves multiple leading boolean flags preserving relative order', () => {
+      expect(hoistFlagsAfterSubcommand(['--use-dev', '--json', 'entity', 'listTaxonomies'])).toEqual([
+        'entity',
+        'listTaxonomies',
+        '--use-dev',
+        '--json',
+      ]);
+    });
+
+    it('handles --verbose short alias -v', () => {
+      expect(hoistFlagsAfterSubcommand(['-v', 'entity', 'listSchemas'])).toEqual(['entity', 'listSchemas', '-v']);
+    });
+
+    it('handles --no-interactive negation flag', () => {
+      expect(hoistFlagsAfterSubcommand(['--no-interactive', 'entity', 'listSchemas'])).toEqual([
+        'entity',
+        'listSchemas',
+        '--no-interactive',
+      ]);
+    });
+  });
+
+  describe('hoisting leading value-taking flags', () => {
+    it('moves --server <url> together as a pair', () => {
+      expect(hoistFlagsAfterSubcommand(['--server', 'http://localhost:9999', 'entity', 'listSchemas'])).toEqual([
+        'entity',
+        'listSchemas',
+        '--server',
+        'http://localhost:9999',
+      ]);
+    });
+
+    it('moves --token <token> together as a pair', () => {
+      expect(hoistFlagsAfterSubcommand(['--token', 'abc123', 'user', 'getMeV2'])).toEqual([
+        'user',
+        'getMeV2',
+        '--token',
+        'abc123',
+      ]);
+    });
+
+    it('moves -t <token> short alias together', () => {
+      expect(hoistFlagsAfterSubcommand(['-t', 'abc123', 'entity', 'listSchemas'])).toEqual([
+        'entity',
+        'listSchemas',
+        '-t',
+        'abc123',
+      ]);
+    });
+
+    it('moves --profile <name> together', () => {
+      expect(hoistFlagsAfterSubcommand(['--profile', 'dev', 'entity', 'listSchemas'])).toEqual([
+        'entity',
+        'listSchemas',
+        '--profile',
+        'dev',
+      ]);
+    });
+
+    it('handles --server=<url> form without consuming next token', () => {
+      expect(hoistFlagsAfterSubcommand(['--server=http://localhost:9999', 'entity', 'listSchemas'])).toEqual([
+        'entity',
+        'listSchemas',
+        '--server=http://localhost:9999',
+      ]);
+    });
+
+    it('does not mistake a value-flag value for the subcommand', () => {
+      // --token value 'entity' must be treated as the token's value, not the subcommand
+      expect(hoistFlagsAfterSubcommand(['--token', 'entity', 'user', 'getMeV2'])).toEqual([
+        'user',
+        'getMeV2',
+        '--token',
+        'entity',
+      ]);
+    });
+  });
+
+  describe('mixed leading flags', () => {
+    it('moves a combination of boolean and value-taking flags', () => {
+      expect(
+        hoistFlagsAfterSubcommand([
+          '--use-dev',
+          '--server',
+          'http://localhost:9999',
+          '--json',
+          'entity',
+          'listSchemas',
+        ]),
+      ).toEqual(['entity', 'listSchemas', '--use-dev', '--server', 'http://localhost:9999', '--json']);
+    });
+
+    it('preserves all positional args after the subcommand', () => {
+      expect(hoistFlagsAfterSubcommand(['--use-dev', 'entity', 'getEntity', 'contact', 'abc123'])).toEqual([
+        'entity',
+        'getEntity',
+        'contact',
+        'abc123',
+        '--use-dev',
+      ]);
+    });
+
+    it('preserves flags that appear after the subcommand alongside hoisted ones', () => {
+      expect(hoistFlagsAfterSubcommand(['--use-dev', 'entity', 'searchEntities', '-d', '{"q":"*"}'])).toEqual([
+        'entity',
+        'searchEntities',
+        '-d',
+        '{"q":"*"}',
+        '--use-dev',
+      ]);
+    });
+  });
+
+  describe('immutability', () => {
+    it('does not mutate the input array', () => {
+      const input = ['--use-dev', 'entity', 'listTaxonomies'];
+      const snapshot = [...input];
+      hoistFlagsAfterSubcommand(input);
+      expect(input).toEqual(snapshot);
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2695,8 +2695,8 @@ importers:
   packages/cli-wrapper:
     dependencies:
       '@epilot/cli':
-        specifier: ^0.1.19
-        version: 0.1.19(@types/node@24.2.0)(js-yaml@4.1.1)
+        specifier: ^0.1.20
+        version: 0.1.20(@types/node@24.2.0)(js-yaml@4.1.1)
 
   packages/epilot-sdk-v2:
     optionalDependencies:
@@ -3082,8 +3082,8 @@ packages:
   '@emotion/hash@0.8.0':
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
 
-  '@epilot/cli@0.1.19':
-    resolution: {integrity: sha512-Mx8cjVPCBmOUEndugkZgUkT7+8pX/+hRKL2x0UItTw9YiqgnRcgZE6eL1RykXhF1NN7Z9z5sp3CUEFhbRyuC9g==}
+  '@epilot/cli@0.1.20':
+    resolution: {integrity: sha512-RiMlJ+KLDEQElTswChPaYEIO17SE5FGJAGIBxLoWwWNYHXKnKXK6o3S4Tqx0Gfp7asQ4vJElk6aK6wt3zrgzgw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8175,7 +8175,7 @@ snapshots:
   '@emotion/hash@0.8.0':
     optional: true
 
-  '@epilot/cli@0.1.19(@types/node@24.2.0)(js-yaml@4.1.1)':
+  '@epilot/cli@0.1.20(@types/node@24.2.0)(js-yaml@4.1.1)':
     dependencies:
       '@inquirer/prompts': 7.10.1(@types/node@24.2.0)
       axios: 1.13.6(debug@4.4.1)


### PR DESCRIPTION
## Summary

Global CLI flags (`--use-dev`, `--json`, `--server`, `--token`, `--profile`, etc.) previously only worked when placed **after** the subcommand + operationId. This PR makes them work in any position.

Before:
- `epilot --use-dev entity listTaxonomies` returned `Forbidden` (flag silently dropped)
- `epilot entity listTaxonomies --use-dev` worked

After, all of these behave identically:
- `epilot --use-dev --json entity listTaxonomies`
- `epilot entity --use-dev --json listTaxonomies`
- `epilot entity listTaxonomies --use-dev --json`

## Root cause

citty dispatches subcommands using `rawArgs.slice(subCommandIdx + 1)`, which drops any tokens (including flags) that appear before the subcommand name. The root command's parsed flags are never forwarded to the subcommand.

## Fix

Pre-process `process.argv` in `bin/epilot.ts` via a new `hoistFlagsAfterSubcommand` helper. Any flags (and their values) that precede the first positional subcommand are moved to the end, so citty sees them after dispatch. The helper is value-aware: `--server <url>`, `--token <tok>`, `--profile <name>`, `-t <tok>`, `-s <url>`, `--definition <file>`, and `--jsonata <expr>` stay paired with their values, so a token like `--token entity` never gets mistaken for the `entity` subcommand. The `=value` form (`--server=http://x`) is handled too.

Implementation lives in `packages/cli/src/lib/reorder-args.ts`. 19 new unit tests cover: empty input, flag-only argv, flags after / between / before the subcommand, boolean vs value-taking flags, short aliases, negation flags (`--no-interactive`), `=value` form, values that look like subcommands, and input immutability.

## Test plan

- [x] `pnpm test` — all 100 tests pass (including 19 new ones for the reorder helper and the full integration suite)
- [x] `pnpm lint` — biome clean on touched files
- [x] Manual smoke: `epilot --use-dev --server https://httpbin.org --token fake entity listSchemas --no-interactive --json` hits httpbin (confirms `--server` was applied)
- [x] Manual smoke: mid-position flags still work (`epilot entity --use-dev ... listSchemas`)
- [x] Manual smoke: post-op flags still work (`epilot entity listSchemas --use-dev ...`)

Generated with Claude Code.
