### PR TITLE
fix(sdk): authorize() no longer stacks request interceptors

### DIFF
--- a/packages/epilot-sdk-v2/__tests__/authorize.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/authorize.test.ts
@@ -1,0 +1,120 @@
+import axios, { type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { authorize } from '../src/authorize';
+
+type ClientWithHandlers = AxiosInstance & {
+  interceptors: {
+    request: AxiosInstance['interceptors']['request'] & {
+      handlers: Array<{ fulfilled: unknown } | null>;
+    };
+    response: AxiosInstance['interceptors']['response'];
+  };
+};
+
+const createClient = () => axios.create() as ClientWithHandlers;
+
+const runRequestInterceptors = async (client: ClientWithHandlers) => {
+  const config = { headers: {} } as InternalAxiosRequestConfig;
+  let current: InternalAxiosRequestConfig = config;
+  // Axios runs request interceptors in REVERSE registration order.
+  for (let i = client.interceptors.request.handlers.length - 1; i >= 0; i--) {
+    const handler = client.interceptors.request.handlers[i];
+    if (!handler || typeof handler.fulfilled !== 'function') continue;
+    const fn = handler.fulfilled as (
+      c: InternalAxiosRequestConfig,
+    ) => InternalAxiosRequestConfig | Promise<InternalAxiosRequestConfig>;
+    current = await fn(current);
+  }
+  return current;
+};
+
+const countActiveHandlers = (client: ClientWithHandlers) =>
+  client.interceptors.request.handlers.filter((h) => h !== null).length;
+
+describe('authorize() — interceptor lifecycle', () => {
+  let client: ClientWithHandlers;
+
+  beforeEach(() => {
+    client = createClient();
+  });
+
+  it('last call wins when re-authorizing with a function token (regression: cross-org write bug)', async () => {
+    authorize(client, () => 'source-org-token');
+    authorize(client, () => 'target-org-token');
+
+    const result = await runRequestInterceptors(client);
+    expect(result.headers.authorization).toBe('Bearer target-org-token');
+  });
+
+  it('ejects the prior auth interceptor instead of stacking them', async () => {
+    authorize(client, () => 'token-A');
+    authorize(client, () => 'token-B');
+    authorize(client, () => 'token-C');
+
+    expect(countActiveHandlers(client)).toBe(1);
+
+    const result = await runRequestInterceptors(client);
+    expect(result.headers.authorization).toBe('Bearer token-C');
+  });
+
+  it('does not grow the interceptor list unbounded across many authorize() calls', () => {
+    for (let i = 0; i < 50; i++) {
+      authorize(client, () => `token-${i}`);
+    }
+    expect(countActiveHandlers(client)).toBe(1);
+  });
+
+  it('switching from function-form to string-form clears the prior interceptor', async () => {
+    authorize(client, () => 'function-token');
+    expect(countActiveHandlers(client)).toBe(1);
+
+    authorize(client, 'static-token');
+
+    expect(countActiveHandlers(client)).toBe(0);
+    expect(client.defaults.headers.common.authorization).toBe('Bearer static-token');
+  });
+
+  it('switching from string-form to function-form clears the stale default header', async () => {
+    authorize(client, 'static-token');
+    expect(client.defaults.headers.common.authorization).toBe('Bearer static-token');
+
+    authorize(client, () => 'dynamic-token');
+
+    expect(client.defaults.headers.common.authorization).toBeUndefined();
+    const result = await runRequestInterceptors(client);
+    expect(result.headers.authorization).toBe('Bearer dynamic-token');
+  });
+
+  it('string form remains a simple defaults overwrite (no interceptor)', () => {
+    authorize(client, 'token-1');
+    expect(client.defaults.headers.common.authorization).toBe('Bearer token-1');
+    expect(countActiveHandlers(client)).toBe(0);
+
+    authorize(client, 'token-2');
+    expect(client.defaults.headers.common.authorization).toBe('Bearer token-2');
+    expect(countActiveHandlers(client)).toBe(0);
+  });
+
+  it('preserves unrelated request interceptors registered by other code', async () => {
+    client.interceptors.request.use((config) => {
+      config.headers['x-trace-id'] = 'trace-xyz';
+      return config;
+    });
+
+    authorize(client, () => 'token-A');
+    authorize(client, () => 'token-B');
+
+    // One unrelated tracer + one auth interceptor.
+    expect(countActiveHandlers(client)).toBe(2);
+
+    const result = await runRequestInterceptors(client);
+    expect(result.headers.authorization).toBe('Bearer token-B');
+    expect(result.headers['x-trace-id']).toBe('trace-xyz');
+  });
+
+  it('returns the client to support chaining', () => {
+    const result = authorize(client, () => 'token');
+    expect(result).toBe(client);
+  });
+});

--- a/packages/epilot-sdk-v2/src/authorize.ts
+++ b/packages/epilot-sdk-v2/src/authorize.ts
@@ -2,17 +2,46 @@ import type { AxiosInstance } from 'axios';
 
 export type TokenArg = string | (() => string | Promise<string>);
 
+// Marker used to track the auth request-interceptor id we previously installed
+// on a given axios client. Using `Symbol.for` keeps the marker stable across
+// module instances (e.g. when the SDK is loaded via both ESM and CJS in the
+// same process).
+const AUTH_INTERCEPTOR_KEY = Symbol.for('@epilot/sdk:authInterceptorId');
+
+type ClientWithAuthMarker = AxiosInstance & {
+  [AUTH_INTERCEPTOR_KEY]?: number;
+};
+
 export const authorize = <T extends AxiosInstance>(client: T, token: TokenArg): T => {
+  const marked = client as T & ClientWithAuthMarker;
+
+  // Always remove any previously-installed auth interceptor first. Axios runs
+  // request interceptors in REVERSE registration order, so re-calling
+  // `authorize()` without ejecting the old one means the OLDEST token wins —
+  // exactly the opposite of what callers expect when they re-authorize the
+  // same client (e.g. switching between source/target org tokens).
+  const prev = marked[AUTH_INTERCEPTOR_KEY];
+  if (typeof prev === 'number') {
+    client.interceptors.request.eject(prev);
+    marked[AUTH_INTERCEPTOR_KEY] = undefined;
+  }
+
   if (typeof token === 'string') {
     client.defaults.headers.common.authorization = `Bearer ${token}`;
-  } else {
-    client.interceptors.request.use(async (config) => {
-      const resolved = await token();
-      config.headers.authorization = `Bearer ${resolved}`;
-
-      return config;
-    });
+    return client;
   }
+
+  // Clear any stale static header from a previous string-form authorize() so
+  // the function-form is the single source of truth for this client.
+  delete client.defaults.headers.common.authorization;
+
+  const id = client.interceptors.request.use(async (config) => {
+    const resolved = await token();
+    config.headers.authorization = `Bearer ${resolved}`;
+
+    return config;
+  });
+  marked[AUTH_INTERCEPTOR_KEY] = id;
 
   return client;
 };


### PR DESCRIPTION
## Summary

`authorize(client, fn)` registered a new request interceptor on every call without ever ejecting the prior one. Because axios runs request interceptors in **reverse registration order**, the **oldest** token always won at request time — exactly the opposite of what callers expect when they re-authorize a singleton client.

## Real-world bug this fixes

We just hit this in `configuration-hub-api`'s cross-org sync feature:

- Phase 0 (read source org): `authorize(entityClient, () => sourceToken)`
- Phase A (write target org): `authorize(entityClient, () => targetToken)`
- HTTP POST goes out → axios runs both interceptors in reverse → **source token wins**
- Every "create" landed on the **source** org instead of the target org
- API returned `201` with `org_id=sourceOrg`; the orchestrator stored phantom `target_id` values that 404 on lookup
- Lineage table got polluted

Confirmed via direct `curl`: the target token writes correctly to the target org when used standalone. The bug is purely in the interceptor stacking.

## What changed

- Track the previously-installed auth interceptor id on the client via a `Symbol.for('@epilot/sdk:authInterceptorId')` marker
- Eject the prior interceptor before installing a new one
- When switching into function-form, also clear any stale `defaults.headers.common.authorization` left over from a previous string-form call so the two forms cannot race
- No public API change; signature is identical

## Tests

Added `packages/epilot-sdk-v2/__tests__/authorize.test.ts` (8 new tests, using real `axios.create()` and the public `interceptors.request.handlers` array — not mocks):

- Last call wins when re-authorizing with a function token (regression for the cross-org bug)
- Re-authorizing N times keeps exactly **one** active auth interceptor
- 50 successive `authorize()` calls do not grow the handler list
- function-form → string-form clears the prior interceptor
- string-form → function-form clears the stale default header
- String form remains a simple defaults overwrite (no interceptor)
- Unrelated request interceptors (e.g. tracing) are preserved across re-authorization
- Still returns the client to support chaining

## Test plan

- [x] `pnpm test` passes (318 tests, +8 new)
- [x] `pnpm build` succeeds
- [x] `pnpm lint` clean
- [ ] Verify the configuration-hub-api cross-org sync writes land on the target org after picking up this SDK release

🤖 Generated with Claude Opus 4.7 (1M context)
