### PR TITLE
fix(design): sync src/definitions/design.json to template server URL (prevent prod leak)

### DIFF
--- a/packages/epilot-sdk-v2/src/definitions/design.json
+++ b/packages/epilot-sdk-v2/src/definitions/design.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Design Builder API v2",
-    "version": "0.0.1"
+    "version": "0.0.3"
   },
   "tags": [
     {
@@ -12,7 +12,17 @@
   ],
   "servers": [
     {
-      "url": "https://design-builder-api.epilot.io"
+      "url": "https://design-builder-api.{environment}.epilot.io",
+      "variables": {
+        "environment": {
+          "default": "sls",
+          "enum": [
+            "sls",
+            "dev.sls",
+            "staging.sls"
+          ]
+        }
+      }
     }
   ],
   "security": [
@@ -26,17 +36,16 @@
         "operationId": "getAllDesigns",
         "summary": "getAllDesigns",
         "description": "Scan all designs linked to a organization, based in orgId attribute from JWT auth token",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "responses": {
           "200": {
             "description": "Success - designs loaded with success. Empty array if org has no designs.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/GetAllDesignsRes"
-                  }
+                  "$ref": "#/components/schemas/GetAllDesignsRes"
                 }
               }
             }
@@ -57,7 +66,9 @@
         "operationId": "addDesign",
         "summary": "addDesign",
         "description": "Create a brand new design linked to a organization, based in orgId attribute from JWT auth token",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "requestBody": {
           "description": "Design payload",
           "required": true,
@@ -118,17 +129,17 @@
         "operationId": "getDesign",
         "summary": "getDesign",
         "description": "Search for a especific design owned by user organization",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "designId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           }
         ],
         "responses": {
@@ -181,17 +192,17 @@
         "operationId": "deleteDesign",
         "summary": "deleteDesign",
         "description": "Search and delete for a especific design owned by user organization",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "designId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           }
         ],
         "responses": {
@@ -237,17 +248,17 @@
         "operationId": "updateDesign",
         "summary": "updateDesign",
         "description": "Update a especific design owned by user organization",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "designId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           }
         ],
         "requestBody": {
@@ -307,21 +318,22 @@
         "summary": "getThemeFromDesign",
         "description": "Search for a especific design owned by user organization and parse them to a new or old theme",
         "security": [],
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "designId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           },
           {
             "in": "query",
             "name": "orgId",
+            "required": false,
             "schema": {
               "type": "string"
             },
@@ -330,13 +342,10 @@
           {
             "in": "query",
             "name": "theme",
-            "schema": {
-              "type": "string",
-              "enum": ["NEW", "OLD"]
-            },
             "required": true,
-            "description": "Type of theme to be parsed and returned",
-            "example": "NEW"
+            "schema": {
+              "$ref": "#/components/schemas/Theme"
+            }
           }
         ],
         "responses": {
@@ -391,7 +400,9 @@
         "operationId": "uploadFile",
         "summary": "uploadFile",
         "description": "Upload a new file for the user organization bucket",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "requestBody": {
           "description": "Upload file payload",
           "required": true,
@@ -455,14 +466,20 @@
         "operationId": "getFiles",
         "summary": "getFiles",
         "description": "List all files for the user organization bucket",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "query",
             "name": "type",
             "schema": {
               "type": "string",
-              "enum": ["LOGO", "FONT"]
+              "enum": [
+                "LOGO",
+                "FONT",
+                "IMAGE"
+              ]
             },
             "required": false,
             "description": "Type of files to be returned",
@@ -519,7 +536,9 @@
         "operationId": "getLimit",
         "summary": "getLimit",
         "description": "Gets designs number limit from database per organization",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "responses": {
           "200": {
             "description": "Success - limit loaded with success.",
@@ -550,7 +569,9 @@
         "operationId": "getBrands",
         "summary": "getBrands",
         "description": "Scan all brands linked to a organization, based in orgId attribute from JWT auth token",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "responses": {
           "200": {
             "description": "Success - brands loaded with success. Empty array if org has no designs.",
@@ -583,27 +604,25 @@
         "operationId": "getConsumerDesign",
         "summary": "getConsumerDesign",
         "description": "Search for a especific design owned by user organization",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "consumerId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           },
           {
             "in": "path",
             "name": "application",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Type of application that uses the design",
-            "example": "journey"
+            "schema": {
+              "$ref": "#/components/schemas/Application"
+            }
           }
         ],
         "responses": {
@@ -658,17 +677,17 @@
         "operationId": "addConsumer",
         "summary": "addConsumer",
         "description": "Add a consumer that uses a specific design",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "designId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           },
           {
             "in": "path",
@@ -737,17 +756,17 @@
         "operationId": "removeConsumer",
         "summary": "removeConsumer",
         "description": "Remove a consumer that uses a specific design",
-        "tags": ["design-builder"],
+        "tags": [
+          "design-builder"
+        ],
         "parameters": [
           {
             "in": "path",
             "name": "designId",
-            "schema": {
-              "type": "string"
-            },
             "required": true,
-            "description": "Id of the design",
-            "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+            "schema": {
+              "$ref": "#/components/schemas/DesignId"
+            }
           },
           {
             "in": "path",
@@ -766,7 +785,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AddConsumerReq"
+                "$ref": "#/components/schemas/RemoveConsumerReq"
               }
             }
           }
@@ -826,7 +845,11 @@
         "properties": {
           "file_type": {
             "type": "string",
-            "enum": ["LOGO", "FONT"]
+            "enum": [
+              "LOGO",
+              "FONT",
+              "IMAGE"
+            ]
           },
           "file_data": {
             "type": "string",
@@ -839,7 +862,11 @@
             "type": "string"
           }
         },
-        "required": ["file_type", "file_name", "file_data"]
+        "required": [
+          "file_type",
+          "file_name",
+          "file_data"
+        ]
       },
       "UploadFileRes": {
         "type": "object",
@@ -915,7 +942,9 @@
             ]
           }
         },
-        "required": ["design"]
+        "required": [
+          "design"
+        ]
       },
       "AddDesignRes": {
         "type": "object",
@@ -976,7 +1005,9 @@
             ]
           }
         },
-        "required": ["design"]
+        "required": [
+          "design"
+        ]
       },
       "ItemMetada": {
         "type": "object",
@@ -1004,7 +1035,7 @@
         "type": "object",
         "properties": {
           "consumer_id": {
-            "type": "string"
+            "$ref": "#/components/schemas/DesignId"
           },
           "consumer_name": {
             "type": "string"
@@ -1013,7 +1044,25 @@
             "type": "string"
           }
         },
-        "required": ["consumer_id", "consumer_name"]
+        "required": [
+          "consumer_id",
+          "consumer_name"
+        ]
+      },
+      "RemoveConsumerReq": {
+        "type": "object",
+        "properties": {
+          "consumer_id": {
+            "$ref": "#/components/schemas/DesignId"
+          },
+          "should_delete": {
+            "type": "string",
+            "deprecated": true
+          }
+        },
+        "required": [
+          "consumer_id"
+        ]
       },
       "DesignItem": {
         "type": "object",
@@ -1068,13 +1117,29 @@
                 "$ref": "#/components/schemas/ConsumerData"
               }
             },
-            "required": ["palette", "typography", "consumer"]
+            "required": [
+              "palette",
+              "typography",
+              "consumer"
+            ]
           },
           "is_default": {
             "type": "boolean"
+          },
+          "_manifest": {
+            "type": "array",
+            "description": "The manifest IDs associated with this design",
+            "items": {
+              "type": "string"
+            }
           }
         },
-        "required": ["style_name", "status", "edited", "style"]
+        "required": [
+          "style_name",
+          "status",
+          "edited",
+          "style"
+        ]
       },
       "BrandItem": {
         "type": "object",
@@ -1107,7 +1172,10 @@
             "type": "string"
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "Custom_Style": {
         "type": "object",
@@ -1125,6 +1193,7 @@
         "properties": {
           "design_tokens": {
             "type": "object",
+            "description": "Design tokens for journey customization",
             "properties": {
               "coupon": {
                 "type": "string"
@@ -1134,6 +1203,255 @@
               },
               "custom_css": {
                 "type": "string"
+              },
+              "accent_color": {
+                "type": "string",
+                "description": "Accent color, defaults to primary"
+              },
+              "outline_color": {
+                "type": "string",
+                "description": "Global outline/focus color"
+              },
+              "divider_color": {
+                "type": "string",
+                "description": "Divider line color"
+              },
+              "link_color": {
+                "type": "string",
+                "description": "Link text color"
+              },
+              "link_hover_color": {
+                "type": "string",
+                "description": "Link hover text color"
+              },
+              "font_size_scale": {
+                "type": "string",
+                "description": "Font size scale factor",
+                "enum": [
+                  "xs",
+                  "sm",
+                  "md",
+                  "lg",
+                  "xl"
+                ]
+              },
+              "topbar_height": {
+                "type": "number",
+                "description": "Topbar minimum height in pixels"
+              },
+              "topbar_logo_alignment": {
+                "type": "string",
+                "description": "Logo/content alignment in the top bar",
+                "enum": [
+                  "flex-start",
+                  "center",
+                  "flex-end"
+                ]
+              },
+              "logo_size": {
+                "type": "number",
+                "description": "Logo size in pixels"
+              },
+              "input_background": {
+                "type": "string",
+                "description": "Input field background color"
+              },
+              "input_border_color": {
+                "type": "string",
+                "description": "Input field border color"
+              },
+              "input_text_color": {
+                "type": "string",
+                "description": "Input field text color"
+              },
+              "input_label_color": {
+                "type": "string",
+                "description": "Input field label color"
+              },
+              "input_border_radius": {
+                "type": "number",
+                "description": "Input field border radius in pixels"
+              },
+              "input_height": {
+                "type": "number",
+                "description": "Input field height in pixels"
+              },
+              "input_variant": {
+                "type": "string",
+                "description": "Input field variant style",
+                "enum": [
+                  "outlined",
+                  "filled",
+                  "underlined"
+                ]
+              },
+              "button_primary_bg": {
+                "type": "string",
+                "description": "Primary button background color or gradient"
+              },
+              "button_primary_text": {
+                "type": "string",
+                "description": "Primary button text color"
+              },
+              "button_primary_hover_bg": {
+                "type": "string",
+                "description": "Primary button hover background color or gradient"
+              },
+              "button_primary_hover_text": {
+                "type": "string",
+                "description": "Primary button hover text color"
+              },
+              "button_outlined_border": {
+                "type": "string",
+                "description": "Outlined button border color"
+              },
+              "button_outlined_text": {
+                "type": "string",
+                "description": "Outlined button text color"
+              },
+              "button_outlined_hover_bg": {
+                "type": "string",
+                "description": "Outlined button hover background color"
+              },
+              "button_outlined_hover_text": {
+                "type": "string",
+                "description": "Outlined button hover text color"
+              },
+              "button_ghost_bg": {
+                "type": "string",
+                "description": "Ghost button background color"
+              },
+              "button_ghost_text": {
+                "type": "string",
+                "description": "Ghost button text color"
+              },
+              "button_ghost_hover_bg": {
+                "type": "string",
+                "description": "Ghost button hover background color"
+              },
+              "button_ghost_hover_text": {
+                "type": "string",
+                "description": "Ghost button hover text color"
+              },
+              "button_border_radius": {
+                "type": "number",
+                "description": "Button border radius in pixels"
+              },
+              "button_height": {
+                "type": "number",
+                "description": "Button height in pixels"
+              },
+              "card_background": {
+                "type": "string",
+                "description": "Card background color"
+              },
+              "card_border_color": {
+                "type": "string",
+                "description": "Card border color for outlined variant"
+              },
+              "card_variant": {
+                "type": "string",
+                "description": "Card visual variant",
+                "enum": [
+                  "shadow",
+                  "outlined"
+                ]
+              },
+              "summary_card_background": {
+                "type": "string",
+                "description": "Summary card background color"
+              },
+              "toggle_selected_bg": {
+                "type": "string",
+                "description": "Toggle button selected background color"
+              },
+              "toggle_selected_text": {
+                "type": "string",
+                "description": "Toggle button selected text color"
+              },
+              "toggle_hover_bg": {
+                "type": "string",
+                "description": "Toggle button hover background color"
+              },
+              "toggle_hover_text": {
+                "type": "string",
+                "description": "Toggle button hover text color"
+              },
+              "toggle_border_color": {
+                "type": "string",
+                "description": "Toggle group wrapper border color"
+              },
+              "dropdown_hover_bg": {
+                "type": "string",
+                "description": "Dropdown option hover background color"
+              },
+              "dropdown_hover_text": {
+                "type": "string",
+                "description": "Dropdown option hover text color"
+              },
+              "dropdown_selected_bg": {
+                "type": "string",
+                "description": "Dropdown option selected background color"
+              },
+              "dropdown_selected_text": {
+                "type": "string",
+                "description": "Dropdown option selected text color"
+              },
+              "switch_unchecked_color": {
+                "type": "string",
+                "description": "Switch unchecked thumb color"
+              },
+              "switch_unchecked_bg": {
+                "type": "string",
+                "description": "Switch unchecked track background color"
+              },
+              "switch_border_radius": {
+                "type": "number",
+                "description": "Switch border radius in pixels"
+              },
+              "checkbox_unchecked_color": {
+                "type": "string",
+                "description": "Checkbox unchecked border color"
+              },
+              "checkbox_label_color": {
+                "type": "string",
+                "description": "Checkbox label text color"
+              },
+              "radio_unchecked_color": {
+                "type": "string",
+                "description": "Radio button unchecked border color"
+              },
+              "radio_label_color": {
+                "type": "string",
+                "description": "Radio button label text color"
+              },
+              "datepicker_selected_bg": {
+                "type": "string",
+                "description": "Date picker selected date background color"
+              },
+              "datepicker_selected_color": {
+                "type": "string",
+                "description": "Date picker selected date text color"
+              },
+              "datepicker_border_radius": {
+                "type": "number",
+                "description": "Date picker border radius in pixels"
+              },
+              "chip_background": {
+                "type": "string",
+                "description": "Chip background color"
+              },
+              "chip_hover_background": {
+                "type": "string",
+                "description": "Chip hover background color"
+              },
+              "chip_text_color": {
+                "type": "string",
+                "description": "Chip text color"
+              },
+              "chip_hover_text_color": {
+                "type": "string",
+                "description": "Chip hover text color"
               }
             }
           }
@@ -1163,7 +1481,10 @@
             }
           }
         },
-        "required": ["widgets", "customer_portals"]
+        "required": [
+          "widgets",
+          "customer_portals"
+        ]
       },
       "WidgetData": {
         "allOf": [
@@ -1213,7 +1534,14 @@
             "type": "string"
           }
         },
-        "required": ["primary", "secondary", "error", "background", "paper", "navbar"]
+        "required": [
+          "primary",
+          "secondary",
+          "error",
+          "background",
+          "paper",
+          "navbar"
+        ]
       },
       "TypographyData": {
         "type": "object",
@@ -1229,7 +1557,11 @@
             "type": "string"
           }
         },
-        "required": ["font", "primary", "secondary"]
+        "required": [
+          "font",
+          "primary",
+          "secondary"
+        ]
       },
       "ShapeData": {
         "type": "object",
@@ -1271,14 +1603,23 @@
             }
           }
         },
-        "required": ["font_id", "font_name", "urls"]
+        "required": [
+          "font_id",
+          "font_name",
+          "urls"
+        ]
       },
       "FontResponseUrl": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["WOFF2", "WOFF", "TTF", "EOT"]
+            "enum": [
+              "WOFF2",
+              "WOFF",
+              "TTF",
+              "EOT"
+            ]
           },
           "url": {
             "type": "string"
@@ -1295,13 +1636,19 @@
             "type": "string"
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "ErrorResp": {
         "type": "object",
         "properties": {
           "message": {
             "type": "string"
+          },
+          "error": {
+            "type": "object"
           }
         }
       },
@@ -1316,7 +1663,11 @@
           },
           "file_type": {
             "type": "string",
-            "enum": ["LOGO", "FONT"]
+            "enum": [
+              "LOGO",
+              "FONT",
+              "IMAGE"
+            ]
           },
           "s3_object_key": {
             "type": "string"
@@ -1325,7 +1676,46 @@
             "type": "string"
           }
         },
-        "required": ["name", "s3_object_key", "url"]
+        "required": [
+          "name",
+          "s3_object_key",
+          "url"
+        ]
+      },
+      "DesignId": {
+        "type": "string",
+        "minLength": 36,
+        "maxLength": 36,
+        "description": "Id of the design",
+        "example": "4a062990-a6a3-11eb-9828-4f3da7d4935a"
+      },
+      "Theme": {
+        "type": "string",
+        "enum": [
+          "NEW",
+          "OLD"
+        ],
+        "description": "Type of theme to be parsed and returned",
+        "example": "NEW"
+      },
+      "Application": {
+        "type": "string",
+        "description": "Type of application that uses the design",
+        "example": "journey"
+      },
+      "DesignParameters": {
+        "type": "object",
+        "properties": {
+          "designId": {
+            "$ref": "#/components/schemas/DesignId"
+          },
+          "theme": {
+            "$ref": "#/components/schemas/Theme"
+          },
+          "application": {
+            "$ref": "#/components/schemas/Application"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Two copies of `design.json` in the SDK were out of sync. The stale `src/` copy hardcoded `https://design-builder-api.epilot.io` — no `.sls` infix, no `{environment}` template — which got bundled into the design SDK chunk and routed callers to **production** regardless of stage.

Replace `packages/epilot-sdk-v2/src/definitions/design.json` with the up-to-date v0.0.3 spec already present at `packages/epilot-sdk-v2/definitions/design.json`, so every bundled chunk resolves the same `https://design-builder-api.{environment}.epilot.io` template.

## Symptom this fixes

Cross-org config sync from `configuration-hub-api` on dev was writing designs into **prod** design-builder. Reads from dev then 4xx/404d (the design did not live in dev), and target journeys ended up with `design: {}` blocks. Lineage rows on the dev tenant pointed at design ids that only existed in prod.

## Verification

- The other design.json (`definitions/design.json` v0.0.3) already had the correct template URL — this MR just brings `src/definitions/design.json` in line.
- Direct curl to `https://design-builder-api.dev.sls.epilot.io` returns valid responses (verified before opening this PR).

## Test plan

- [x] `src/definitions/design.json` now matches `definitions/design.json` (file is the v0.0.3 source-of-truth)
- [ ] CI green
- [ ] After release: configuration-hub-api dev sync writes designs to dev DB, target journeys load with populated `design.style.consumer`

🤖 Generated with Claude Code