### PR TITLE
fix(ci): publish epilot CLI wrapper via pnpm (fixes broken npx epilot)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           else
             echo "sdk=false" >> "$GITHUB_OUTPUT"
           fi
-          if echo "$CHANGED_FILES" | grep -qE '^(packages/cli/|clients/.*/openapi\.json$)'; then
+          if echo "$CHANGED_FILES" | grep -qE '^(packages/cli/|packages/cli-wrapper/|clients/.*/openapi\.json$)'; then
             echo "cli=true" >> "$GITHUB_OUTPUT"
           else
             echo "cli=false" >> "$GITHUB_OUTPUT"
@@ -173,17 +173,17 @@ jobs:
 
       - name: Publish @epilot/sdk
         if: steps.check.outputs.sdk == 'true'
-        run: npm publish --ignore-scripts
+        run: pnpm publish --ignore-scripts --no-git-checks
         working-directory: packages/epilot-sdk-v2
 
       - name: Publish @epilot/cli
         if: steps.check.outputs.cli == 'true'
-        run: npm publish --ignore-scripts
+        run: pnpm publish --ignore-scripts --no-git-checks
         working-directory: packages/cli
 
       - name: Publish epilot wrapper
         if: steps.check.outputs.cli == 'true'
-        run: npm publish --ignore-scripts
+        run: pnpm publish --ignore-scripts --no-git-checks
         working-directory: packages/cli-wrapper
 
   publish-sdk:
@@ -207,7 +207,7 @@ jobs:
       - run: pnpm build
 
       - name: Publish @epilot/sdk
-        run: npm publish --ignore-scripts
+        run: pnpm publish --ignore-scripts --no-git-checks
         working-directory: packages/epilot-sdk-v2
 
   publish-cli:
@@ -231,9 +231,9 @@ jobs:
       - run: pnpm --filter @epilot/cli build
 
       - name: Publish @epilot/cli
-        run: npm publish --ignore-scripts || true
+        run: pnpm publish --ignore-scripts --no-git-checks || true
         working-directory: packages/cli
 
       - name: Publish epilot wrapper
-        run: npm publish --ignore-scripts
+        run: pnpm publish --ignore-scripts --no-git-checks
         working-directory: packages/cli-wrapper

--- a/packages/cli-wrapper/package.json
+++ b/packages/cli-wrapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "epilot",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "description": "CLI for epilot APIs (wrapper for @epilot/cli)",
   "bin": {
     "epilot": "./bin/epilot.js"


### PR DESCRIPTION
## Problem

\`npx epilot\` fails for everyone with:

\`\`\`
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:^
\`\`\`

The \`epilot\` wrapper package (\`packages/cli-wrapper\`) depends on \`@epilot/cli\` via \`workspace:^\`. That protocol must be rewritten to a concrete version at publish time. **pnpm does this; npm does not.** The CI publish steps used \`npm publish\`, so \`epilot@0.1.30\`–\`0.1.36\` all shipped \`"@epilot/cli": "workspace:^"\` verbatim to the registry, breaking every install. The regression entered at 0.1.30 when these steps switched to plain \`npm publish\`.

## Fix

- **Switch all publish steps to \`pnpm publish --ignore-scripts --no-git-checks\`** — pnpm rewrites \`workspace:^\` to a real version (\`^0.1.x\`) at pack time.
- **Add \`packages/cli-wrapper/\` to the \`cli=true\` release trigger** — wrapper-only changes previously did not trigger any release, which is part of why the wrapper drifted unnoticed.
- **Bump wrapper to 0.1.37** as the triggering change for a corrected republish.

## On merge

\`auto-release\` runs on push to \`main\`, sees the wrapper change → \`cli=true\`, bumps \`@epilot/cli\` to 0.1.37, sets the wrapper to match, and publishes both via CI's npm credentials. The published \`epilot@0.1.37\` will carry a concrete \`@epilot/cli\` version instead of \`workspace:^\`.

## Verify after merge

\`\`\`
npm view epilot@0.1.37 dependencies   # expect { '@epilot/cli': '^0.1.37' }, not workspace:^
npx epilot --help
\`\`\`

## Interim workaround (until merged)

\`npx @epilot/cli@latest\` — the underlying package is unaffected and exposes the same \`epilot\` bin.