### PR TITLE
feat(workflow-client): add runTaskAgent + trigger_mode on AiAgentTask

### DIFF
--- a/.changeset/workflow-client-run-task-agent.md
+++ b/.changeset/workflow-client-run-task-agent.md
@@ -1,0 +1,8 @@
+---
+"@epilot/workflow-client": minor
+---
+
+Add `runTaskAgent` and surface `trigger_mode` on `AiAgentTask`
+
+- New `POST /v2/flows/executions/{execution_id}/tasks/{task_id}/agent:run` operation (`runTaskAgent`). Dispatches the configured AI agent for a manual-trigger AI task after an explicit user action.
+- `AiAgentTask` now exposes the optional `trigger_mode` field (`'manual' | 'automatic'`), mirroring `AutomationTask`. Undefined is treated as automatic by the backend (no data migration needed).

--- a/clients/workflow-client/src/openapi-runtime.json
+++ b/clients/workflow-client/src/openapi-runtime.json
@@ -273,6 +273,20 @@
         "responses": {}
       }
     },
+    "/v2/flows/executions/{execution_id}/tasks/{task_id}/agent:run": {
+      "post": {
+        "operationId": "runTaskAgent",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ExecutionIdParam"
+          },
+          {
+            "$ref": "#/components/parameters/TaskIdParam"
+          }
+        ],
+        "responses": {}
+      }
+    },
     "/v2/flows/executions/{execution_id}/tasks/{task_id}/execute": {
       "post": {
         "operationId": "executeTask",

--- a/clients/workflow-client/src/openapi.d.ts
+++ b/clients/workflow-client/src/openapi.d.ts
@@ -165,6 +165,7 @@ declare namespace Components {
              * ID of the agent execution, used for tracking status updates. This is needed as a separate field to allow indexing.
              */
             agent_execution_id?: string;
+            trigger_mode?: TriggerMode;
         }
         export interface AnalyticsInfo {
             started_at?: string; // date-time
@@ -231,6 +232,14 @@ declare namespace Components {
              *
              */
             AutomationInputContext;
+            /**
+             * Internal — number of times flow-healing-service has attempted to re-trigger this task's lost automation dispatch. Used to cap retries and avoid an indefinite heal-on-every-read storm against a deterministically-failing automation flow.
+             */
+            heal_attempts?: number;
+            /**
+             * Internal — timestamp of the most recent heal attempt for this task. flow-healing-service uses this as a per-task debounce gate so the heal cannot fire more than once per HEAL_RETRY_COOLDOWN_MS regardless of how often the flow execution is read.
+             */
+            last_heal_attempted_at?: string; // date-time
         }
         /**
          * Optional. Source of the entity fed into this automation task. If omitted, the workflow's primary entity is used.
@@ -594,8 +603,18 @@ declare namespace Components {
                 entityAttribute: string;
             };
         }
+        /**
+         * Standard error response returned when an API request fails.
+         * Contains a human-readable message describing the error.
+         *
+         */
         export interface ErrorResp {
-            message?: string;
+            /**
+             * Human-readable description of the error that occurred
+             * example:
+             * Validation failed: workflowId is required
+             */
+            message: string;
         }
         export interface EvaluationSource {
             /**
@@ -609,6 +628,34 @@ declare namespace Components {
             attribute_type?: "string" | "text" | "number" | "boolean" | "date" | "datetime" | "tags" | "country" | "email" | "phone" | "product" | "price" | "status" | "relation" | "multiselect" | "select" | "radio" | "relation_user" | "purpose" | "label" | "message_email_address";
             attribute_repeatable?: boolean;
             attribute_operation?: "all" | "updated" | "added" | "deleted";
+            /**
+             * Multi-attribute mode. When present and length > 1, the statement is
+             * evaluated against every listed attribute and combined via
+             * `attributes_match`. All listed attributes must share the same
+             * `attribute_type`. Mutually exclusive with `attribute_sub_field`,
+             * `date_offset`, and `attribute_operation`. When absent or length === 1,
+             * the legacy `attribute` field is used.
+             *
+             */
+            attributes?: [
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?
+            ];
+            /**
+             * Inner connector across `attributes`. `any` (default) means at least
+             * one attribute must satisfy the operator; `all` means every attribute
+             * must satisfy it. Ignored when `attributes` is absent or has length < 2.
+             *
+             */
+            attributes_match?: "any" | "all";
             /**
              * For complex attribute types, specifies which sub-field to extract (e.g., 'address', 'name', 'email_type')
              */
@@ -685,6 +732,10 @@ declare namespace Components {
             contexts: FlowContext[];
             crt_tasks: {
                 id?: TaskId;
+                /**
+                 * Timestamp when this task entered crt_tasks (i.e. became current). Used by the flow-healing-service as the authoritative gate for "has this PENDING task been stuck long enough to heal?". Using the task's own analytics.status_updated_at as the gate produced false positives because transitioning a task INTO crt_tasks does not change its status — so that timestamp can be hours old for a freshly-current task.
+                 */
+                crt_since?: string; // date-time
             }[];
             phases?: Phase[];
             tasks: Task[];
@@ -873,7 +924,17 @@ declare namespace Components {
             due_date_config?: /* Set due date for the task based on a dynamic condition */ DueDateConfig;
             assigned_to?: /* The user ids or variable assignments */ Assignees;
         }
+        /**
+         * Request payload for updating a task within a flow execution.
+         * All fields are optional; only provided fields will be updated.
+         *
+         */
         export interface PatchTaskReq {
+            /**
+             * Display name of the task
+             * example:
+             * Review customer application
+             */
             name?: string;
             status?: /**
              * **Note**: "UNASSIGNED" and "ASSIGNED" are deprecated and will be removed in a future version. Please use "PENDING" instead. Status values for workflow execution steps/tasks:
@@ -892,14 +953,37 @@ declare namespace Components {
              */
             StepStatus;
             /**
+             * Explicit due date for the task. Takes precedence over
+             * due_date_config if both are provided.
+             *
+             * Note: intentionally typed as plain `string` (not
+             * `format: date-time`). For day/week/month-precision due
+             * dates the server stores a "floating" datetime without a
+             * timezone designator (e.g. `2026-05-28T00:00:00.000`) so
+             * that the UI can render it as a date in the user's local
+             * timezone without shifting the displayed day. Tightening
+             * this to `format: date-time` causes openapi-zod-client to
+             * emit `z.string().datetime({ offset: true })` in
+             * `validators-generated.ts`, which then trips
+             * `safeParse(body)` in `patch-task.ts` whenever the
+             * sidebar sends a stored task back with a tz-less
+             * `due_date`. See commit 4aca299c (Aug 2024) for the
+             * original date-only display rationale and the May 2026
+             * incident (513ed597 added the format, ee574b43
+             * unintentionally activated it via an unrelated regen) for
+             * the history. Long-term, day-precision due dates should
+             * migrate to a separate `format: date` field.
+             *
              * example:
-             * 2021-04-27T12:00:00.000Z
+             * 2026-05-28T00:00:00.000
              */
             due_date?: string;
             due_date_config?: /* Set due date for the task based on a dynamic condition */ DueDateConfig;
             assigned_to?: /* The user ids or variable assignments */ Assignees;
             /**
-             * flag for controlling enabled/disabled state of the task
+             * Controls whether the task is enabled (can be worked on) or disabled (grayed out).
+             * Disabled tasks cannot have their status changed until re-enabled.
+             *
              */
             enabled?: boolean;
             automation_config?: AutomationInfo;
@@ -911,14 +995,25 @@ declare namespace Components {
              */
             partner?: /* Details regarding partner for the workflow step */ PartnerDetails;
             /**
-             * Condition to evaluate as true for a decision task with a manual trigger mode
+             * For decision tasks with manual trigger mode, specifies which condition/branch
+             * to follow when completing the task. The condition ID must match one of the
+             * conditions defined on the decision task.
+             *
+             * example:
+             * cond_branch_approved
              */
             next_condition_id?: string;
             /**
-             * When patching an already completed/skipped task that comes before the current task, this flag controls whether to revert the execution:
-             * - `true`: The patched task becomes the current task AND all succeeding tasks are reset to PENDING (full revert)
-             * - `false` or omitted (undefined): The task is updated but the current task does not change and no downstream tasks are affected
-             * This parameter is silently ignored when patching the current task or future tasks.
+             * Controls behavior when updating a task that was already completed/skipped and
+             * comes before the current task in the workflow:
+             * - `true`: Reverts the execution - the patched task becomes the current task
+             *   and all subsequent tasks are reset to PENDING status
+             * - `false` (default): Updates only this task without affecting workflow position
+             *   or other tasks
+             *
+             * **Important:** This parameter is silently ignored when:
+             * - Patching the current task
+             * - Patching future tasks (tasks that haven't been reached yet)
              *
              */
             revert_execution?: boolean;
@@ -1184,15 +1279,35 @@ declare namespace Components {
             assignedTo?: string[];
         }
         export type SectionStatus = "OPEN" | "IN_PROGRESS" | "COMPLETED";
+        /**
+         * Request payload for starting a new flow execution from a template.
+         *
+         */
         export interface StartFlowReq {
+            /**
+             * The unique identifier of the flow template (definition) to instantiate.
+             * The template must exist and be accessible within the organization.
+             *
+             * example:
+             * tpl_abc123def456
+             */
             flow_template_id: string;
             trigger?: FlowTrigger;
+            /**
+             * Entity references that this execution is linked to. At least one context
+             * is required. The primary context (is_primary: true) is used for condition
+             * evaluation and data mapping.
+             *
+             */
             contexts: [
                 FlowContext,
                 ...FlowContext[]
             ];
             /**
-             * An array of purposes to filter workflow phases.
+             * Taxonomy purpose IDs to filter which phases and tasks are included in the execution.
+             * Only phases/tasks tagged with matching purposes will be active. If empty or omitted,
+             * all phases and tasks from the template are included.
+             *
              */
             purposes?: string[];
         }
@@ -1490,7 +1605,7 @@ declare namespace Components {
         }
         export type TaskId = string;
         export type TaskType = "MANUAL" | "AUTOMATION" | "DECISION" | "AI_AGENT";
-        export type TimeUnit = "minutes" | "hours" | "days" | "weeks" | "months";
+        export type TimeUnit = "minutes" | "hours" | "days" | "weeks" | "months" | "years";
         export type TriggerMode = "manual" | "automatic";
         export type TriggerType = "MANUAL" | "AUTOMATIC";
         export interface UpdateEntityAttributes {
@@ -2004,9 +2119,24 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.AddTaskReq;
         namespace Responses {
             export type $201 = Components.Schemas.Task;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace CancelSchedule {
@@ -2021,10 +2151,30 @@ declare namespace Paths {
         namespace Responses {
             export interface $204 {
             }
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $404 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $404 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace CancelTaskSchedule {
@@ -2039,10 +2189,30 @@ declare namespace Paths {
         namespace Responses {
             export interface $204 {
             }
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $404 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $404 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace CreateExecution {
@@ -2118,9 +2288,24 @@ declare namespace Paths {
              * }
              */
             Components.Schemas.WorkflowExecution;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace CreateStep {
@@ -2133,9 +2318,24 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.CreateStepReq;
         namespace Responses {
             export type $201 = Components.Schemas.Step;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace DeleteExecution {
@@ -2148,7 +2348,12 @@ declare namespace Paths {
         namespace Responses {
             export interface $204 {
             }
-            export type $401 = Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
             export interface $404 {
             }
         }
@@ -2187,7 +2392,12 @@ declare namespace Paths {
         namespace Responses {
             export interface $204 {
             }
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace ExecuteTask {
@@ -2201,9 +2411,24 @@ declare namespace Paths {
         }
         namespace Responses {
             export type $200 = Components.Schemas.Task;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace GetClosingReasonExecution {
@@ -2215,7 +2440,12 @@ declare namespace Paths {
         }
         namespace Responses {
             export type $200 = Components.Schemas.ClosingReasonResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace GetExecution {
@@ -2279,7 +2509,12 @@ declare namespace Paths {
              * }
              */
             Components.Schemas.WorkflowExecution;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace GetExecutions {
@@ -2336,7 +2571,12 @@ declare namespace Paths {
              * }
              */
             Components.Schemas.WorkflowExecutionSlim[];
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace GetFlowExecution {
@@ -2372,7 +2612,12 @@ declare namespace Paths {
             }
             export interface $404 {
             }
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace PatchPhase {
@@ -2387,9 +2632,24 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.PatchPhaseReq;
         namespace Responses {
             export type $200 = Components.Schemas.Phase;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace PatchTask {
@@ -2401,12 +2661,87 @@ declare namespace Paths {
             execution_id: Parameters.ExecutionId;
             task_id: Parameters.TaskId;
         }
-        export type RequestBody = Components.Schemas.PatchTaskReq;
+        export type RequestBody = /**
+         * Request payload for updating a task within a flow execution.
+         * All fields are optional; only provided fields will be updated.
+         *
+         */
+        Components.Schemas.PatchTaskReq;
         namespace Responses {
             export type $200 = Components.Schemas.Task;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $404 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+        }
+    }
+    namespace RunTaskAgent {
+        namespace Parameters {
+            export type ExecutionId = string;
+            export type TaskId = string;
+        }
+        export interface PathParameters {
+            execution_id: Parameters.ExecutionId;
+            task_id: Parameters.TaskId;
+        }
+        namespace Responses {
+            export type $200 = Components.Schemas.AiAgentTask;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $403 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $404 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $409 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace RunTaskAutomation {
@@ -2420,9 +2755,24 @@ declare namespace Paths {
         }
         namespace Responses {
             export type $200 = Components.Schemas.AutomationTask;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace RunTaskScheduleNow {
@@ -2436,19 +2786,54 @@ declare namespace Paths {
         }
         namespace Responses {
             export type $200 = Components.Schemas.Task;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $404 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $404 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace SearchExecutions {
         export type RequestBody = Components.Schemas.SearchExecutionsReq;
         namespace Responses {
             export type $200 = Components.Schemas.SearchExecutionsResp;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace SearchFlowExecutions {
@@ -2457,33 +2842,80 @@ declare namespace Paths {
             export interface $200 {
                 results?: Components.Schemas.FlowExecution[];
             }
-            export type $400 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
             export interface $401 {
             }
             export interface $403 {
             }
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace SearchSteps {
         export type RequestBody = Components.Schemas.SearchStepsReq;
         namespace Responses {
             export type $200 = Components.Schemas.SearchStepsResp;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace StartFlowExecution {
-        export type RequestBody = Components.Schemas.StartFlowReq;
+        export type RequestBody = /**
+         * Request payload for starting a new flow execution from a template.
+         *
+         */
+        Components.Schemas.StartFlowReq;
         namespace Responses {
             export type $201 = Components.Schemas.FlowExecution;
-            export type $400 = Components.Schemas.ErrorResp;
-            export interface $401 {
-            }
-            export interface $403 {
-            }
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $403 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace UpdateExecution {
@@ -2497,7 +2929,12 @@ declare namespace Paths {
         namespace Responses {
             export interface $204 {
             }
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
     namespace UpdateStep {
@@ -2512,9 +2949,24 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.UpdateStepReq;
         namespace Responses {
             export type $200 = Components.Schemas.Step;
-            export type $400 = Components.Schemas.ErrorResp;
-            export type $401 = Components.Schemas.ErrorResp;
-            export type $500 = Components.Schemas.ErrorResp;
+            export type $400 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $401 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
+            export type $500 = /**
+             * Standard error response returned when an API request fails.
+             * Contains a human-readable message describing the error.
+             *
+             */
+            Components.Schemas.ErrorResp;
         }
     }
 }
@@ -2534,7 +2986,13 @@ export interface OperationMethods {
   /**
    * createExecution - createExecution
    * 
-   * Create a Workflow Execution. Start a new workflow execution, based on a workflow definition (template).
+   * Creates a new V1 Workflow Execution from a workflow definition (template).
+   * 
+   * **Note:** This is the legacy V1 API. For new integrations, use `POST /v2/flows/executions` instead.
+   * 
+   * The workflow definition specifies the structure (sections and steps) of the workflow.
+   * When created, the execution instantiates all steps and begins tracking progress.
+   * 
    */
   'createExecution'(
     parameters?: Parameters<UnknownParamsObject> | null,
@@ -2544,7 +3002,10 @@ export interface OperationMethods {
   /**
    * getExecution - getExecution
    * 
-   * Get a full workflow execution, included steps information, by execution id.
+   * Retrieves a complete V1 workflow execution by ID, including all steps information.
+   * 
+   * **Note:** This is the legacy V1 API. For new integrations, use `GET /v2/flows/executions/{execution_id}` instead.
+   * 
    */
   'getExecution'(
     parameters?: Parameters<Paths.GetExecution.PathParameters> | null,
@@ -2584,7 +3045,16 @@ export interface OperationMethods {
   /**
    * updateStep - updateStep
    * 
-   * Patches various changes to a workflow execution step.
+   * Updates a workflow execution step with new values for status, assignees, due date, position, and more.
+   * 
+   * **Note:** This is the legacy V1 API. For new integrations, use `PATCH /v2/flows/executions/{execution_id}/tasks/{task_id}` instead.
+   * 
+   * **Common use cases:**
+   * - Mark a step as completed or skipped
+   * - Assign or reassign users to a step
+   * - Update step due dates (static or dynamic)
+   * - Reorder steps within a section
+   * 
    */
   'updateStep'(
     parameters?: Parameters<Paths.UpdateStep.PathParameters> | null,
@@ -2637,7 +3107,20 @@ export interface OperationMethods {
   /**
    * startFlowExecution - startFlowExecution
    * 
-   * Starts a new Flow Execution based on a flow template.
+   * Starts a new Flow Execution based on a flow template (definition).
+   * 
+   * The flow template defines the structure of the workflow including phases, tasks, edges (transitions),
+   * and automation configurations. When started, the execution creates runtime instances of all tasks
+   * and begins processing from the initial task(s).
+   * 
+   * **Required fields:**
+   * - `flow_template_id`: The ID of the flow template to instantiate
+   * - `contexts`: At least one entity context to link the execution to
+   * 
+   * **Optional fields:**
+   * - `trigger`: Specifies how the execution was triggered (manual or automatic)
+   * - `purposes`: Filter which phases/tasks are included based on taxonomy purposes
+   * 
    */
   'startFlowExecution'(
     parameters?: Parameters<UnknownParamsObject> | null,
@@ -2647,7 +3130,16 @@ export interface OperationMethods {
   /**
    * getFlowExecution - getFlowExecution
    * 
-   * Get a full flow execution, included tasks, phases, edges & analytics.
+   * Retrieves a complete flow execution by ID, including all phases, tasks, edges, contexts, and analytics.
+   * 
+   * The response includes:
+   * - **Execution metadata**: ID, name, status, timestamps, assignees
+   * - **Phases**: Organizational groupings of tasks with progress tracking
+   * - **Tasks**: Individual work items with their status, assignees, and configurations
+   * - **Edges**: Connections between tasks defining the workflow graph
+   * - **Analytics**: Timing information (started, completed, closed timestamps)
+   * - **Contexts**: Linked entity references
+   * 
    */
   'getFlowExecution'(
     parameters?: Parameters<Paths.GetFlowExecution.PathParameters> | null,
@@ -2687,7 +3179,26 @@ export interface OperationMethods {
   /**
    * patchTask - patchTask
    * 
-   * Changes various attributes of a flow task, like assignees, status, due date, etc.
+   * Updates attributes of a flow task including status, assignees, due date, and more.
+   * 
+   * **Common use cases:**
+   * - Mark a task as completed or skipped
+   * - Assign or reassign users to a task
+   * - Update task due dates
+   * - Enable or disable a task
+   * - Revert execution to a previous task
+   * 
+   * **Status transitions:**
+   * - `PENDING` -> `IN_PROGRESS`: User starts working on the task
+   * - `IN_PROGRESS` -> `COMPLETED`: User finishes the task
+   * - `PENDING` or `IN_PROGRESS` -> `SKIPPED`: Task is bypassed
+   * - `COMPLETED` or `SKIPPED` -> `PENDING`: Task is reopened (with revert_execution flag)
+   * 
+   * **Reverting execution:**
+   * When updating a task that was already completed/skipped and comes before the current task,
+   * use `revert_execution: true` to reset the flow back to that point. All subsequent tasks
+   * will be reset to PENDING status.
+   * 
    */
   'patchTask'(
     parameters?: Parameters<Paths.PatchTask.PathParameters> | null,
@@ -2704,6 +3215,16 @@ export interface OperationMethods {
     data?: any,
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.RunTaskAutomation.Responses.$200>
+  /**
+   * runTaskAgent - runTaskAgent
+   * 
+   * Dispatches the configured AI agent for a flow task. Used when the task's trigger_mode is 'manual', so the agent only runs after an explicit user action.
+   */
+  'runTaskAgent'(
+    parameters?: Parameters<Paths.RunTaskAgent.PathParameters> | null,
+    data?: any,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.RunTaskAgent.Responses.$200>
   /**
    * executeTask - executeTask
    * 
@@ -2784,7 +3305,13 @@ export interface PathsDictionary {
     /**
      * createExecution - createExecution
      * 
-     * Create a Workflow Execution. Start a new workflow execution, based on a workflow definition (template).
+     * Creates a new V1 Workflow Execution from a workflow definition (template).
+     * 
+     * **Note:** This is the legacy V1 API. For new integrations, use `POST /v2/flows/executions` instead.
+     * 
+     * The workflow definition specifies the structure (sections and steps) of the workflow.
+     * When created, the execution instantiates all steps and begins tracking progress.
+     * 
      */
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
@@ -2796,7 +3323,10 @@ export interface PathsDictionary {
     /**
      * getExecution - getExecution
      * 
-     * Get a full workflow execution, included steps information, by execution id.
+     * Retrieves a complete V1 workflow execution by ID, including all steps information.
+     * 
+     * **Note:** This is the legacy V1 API. For new integrations, use `GET /v2/flows/executions/{execution_id}` instead.
+     * 
      */
     'get'(
       parameters?: Parameters<Paths.GetExecution.PathParameters> | null,
@@ -2840,7 +3370,16 @@ export interface PathsDictionary {
     /**
      * updateStep - updateStep
      * 
-     * Patches various changes to a workflow execution step.
+     * Updates a workflow execution step with new values for status, assignees, due date, position, and more.
+     * 
+     * **Note:** This is the legacy V1 API. For new integrations, use `PATCH /v2/flows/executions/{execution_id}/tasks/{task_id}` instead.
+     * 
+     * **Common use cases:**
+     * - Mark a step as completed or skipped
+     * - Assign or reassign users to a step
+     * - Update step due dates (static or dynamic)
+     * - Reorder steps within a section
+     * 
      */
     'patch'(
       parameters?: Parameters<Paths.UpdateStep.PathParameters> | null,
@@ -2901,7 +3440,20 @@ export interface PathsDictionary {
     /**
      * startFlowExecution - startFlowExecution
      * 
-     * Starts a new Flow Execution based on a flow template.
+     * Starts a new Flow Execution based on a flow template (definition).
+     * 
+     * The flow template defines the structure of the workflow including phases, tasks, edges (transitions),
+     * and automation configurations. When started, the execution creates runtime instances of all tasks
+     * and begins processing from the initial task(s).
+     * 
+     * **Required fields:**
+     * - `flow_template_id`: The ID of the flow template to instantiate
+     * - `contexts`: At least one entity context to link the execution to
+     * 
+     * **Optional fields:**
+     * - `trigger`: Specifies how the execution was triggered (manual or automatic)
+     * - `purposes`: Filter which phases/tasks are included based on taxonomy purposes
+     * 
      */
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,
@@ -2913,7 +3465,16 @@ export interface PathsDictionary {
     /**
      * getFlowExecution - getFlowExecution
      * 
-     * Get a full flow execution, included tasks, phases, edges & analytics.
+     * Retrieves a complete flow execution by ID, including all phases, tasks, edges, contexts, and analytics.
+     * 
+     * The response includes:
+     * - **Execution metadata**: ID, name, status, timestamps, assignees
+     * - **Phases**: Organizational groupings of tasks with progress tracking
+     * - **Tasks**: Individual work items with their status, assignees, and configurations
+     * - **Edges**: Connections between tasks defining the workflow graph
+     * - **Analytics**: Timing information (started, completed, closed timestamps)
+     * - **Contexts**: Linked entity references
+     * 
      */
     'get'(
       parameters?: Parameters<Paths.GetFlowExecution.PathParameters> | null,
@@ -2957,7 +3518,26 @@ export interface PathsDictionary {
     /**
      * patchTask - patchTask
      * 
-     * Changes various attributes of a flow task, like assignees, status, due date, etc.
+     * Updates attributes of a flow task including status, assignees, due date, and more.
+     * 
+     * **Common use cases:**
+     * - Mark a task as completed or skipped
+     * - Assign or reassign users to a task
+     * - Update task due dates
+     * - Enable or disable a task
+     * - Revert execution to a previous task
+     * 
+     * **Status transitions:**
+     * - `PENDING` -> `IN_PROGRESS`: User starts working on the task
+     * - `IN_PROGRESS` -> `COMPLETED`: User finishes the task
+     * - `PENDING` or `IN_PROGRESS` -> `SKIPPED`: Task is bypassed
+     * - `COMPLETED` or `SKIPPED` -> `PENDING`: Task is reopened (with revert_execution flag)
+     * 
+     * **Reverting execution:**
+     * When updating a task that was already completed/skipped and comes before the current task,
+     * use `revert_execution: true` to reset the flow back to that point. All subsequent tasks
+     * will be reset to PENDING status.
+     * 
      */
     'patch'(
       parameters?: Parameters<Paths.PatchTask.PathParameters> | null,
@@ -2976,6 +3556,18 @@ export interface PathsDictionary {
       data?: any,
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.RunTaskAutomation.Responses.$200>
+  }
+  ['/v2/flows/executions/{execution_id}/tasks/{task_id}/agent:run']: {
+    /**
+     * runTaskAgent - runTaskAgent
+     * 
+     * Dispatches the configured AI agent for a flow task. Used when the task's trigger_mode is 'manual', so the agent only runs after an explicit user action.
+     */
+    'post'(
+      parameters?: Parameters<Paths.RunTaskAgent.PathParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.RunTaskAgent.Responses.$200>
   }
   ['/v2/flows/executions/{execution_id}/tasks/{task_id}/execute']: {
     /**

--- a/clients/workflow-client/src/openapi.json
+++ b/clients/workflow-client/src/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Workflows Executions",
     "version": "1.0.0",
-    "description": "Service for Workflow Executions which covers executions of processes defined in an Organization\n"
+    "description": "## Overview\nThe Workflows Executions API manages the runtime instances of workflow processes within an organization.\nWhile **Workflow Definitions** (managed by the Workflows Definitions API) serve as reusable templates\nthat define the structure, phases, and tasks of a process, **Workflow Executions** are the active\ninstances created from those definitions.\n\n## Key Concepts\n\n### Definitions vs Executions\n- **Definition (Template)**: A blueprint defining workflow structure, phases, tasks, conditions, and automation rules\n- **Execution (Instance)**: A running instance of a definition, tracking actual progress, assignees, and status\n\n### Execution Lifecycle\n1. **STARTED**: Execution is active and tasks can be worked on\n2. **DONE**: All required tasks are completed\n3. **CLOSED**: Execution is terminated (completed successfully or cancelled with closing reasons)\n\n### Task Types\n- **Manual Tasks**: Require human action to complete\n- **Automation Tasks**: Execute configured automations automatically\n- **Decision Tasks**: Evaluate conditions to determine the next path in the workflow\n- **AI Agent Tasks**: Execute AI-powered agents for intelligent task processing\n\n### Contexts\nExecutions are linked to entity contexts (e.g., contacts, opportunities) that provide the data\ncontext for the workflow and allow tracking which entities a workflow operates on.\n\n## API Versions\n- **V1 (`/v1/workflows/`)**: Legacy linear phase/section/step model (deprecated for new integrations)\n- **V2 (`/v2/flows/`)**: Current graph-based model with advanced features like conditional branching,\n  loops, and scheduling. **Recommended for all new integrations.**\n"
   },
   "servers": [
     {
@@ -13,16 +13,19 @@
   "tags": [
     {
       "name": "Workflow Executions",
-      "description": "Interact with workflow executions - start / close / retrieve one or all / search / delete"
+      "description": "Manage V1 workflow executions (legacy linear model). Operations include starting new executions\nfrom definitions, retrieving execution details, updating execution status and assignees,\nand deleting executions. Use the Flows V2 endpoints for new integrations.\n"
     },
     {
-      "name": "Workflow Steps"
+      "name": "Workflow Steps",
+      "description": "Manage individual steps within V1 workflow executions (legacy). Steps represent discrete tasks\nthat can be assigned to users, have due dates, and track completion status. Use the Flows V2\ntask endpoints for new integrations.\n"
     },
     {
-      "name": "Closing Reasons"
+      "name": "Closing Reasons",
+      "description": "Retrieve closing reasons configured for workflow executions. When a workflow is closed/cancelled,\nusers can select from predefined closing reasons to document why the workflow ended. Closing\nreasons are snapshots from the definition at execution creation time.\n"
     },
     {
-      "name": "Flows V2"
+      "name": "Flows V2",
+      "description": "**Recommended for new integrations.** Manage V2 flow executions using the graph-based execution model.\nThis API version supports advanced features including:\n- Conditional branching with decision tasks\n- Automation tasks with configurable triggers\n- AI agent tasks for intelligent processing\n- Task scheduling (immediate, delayed, or relative to events)\n- Loop iterations for repeatable task sequences\n- Phase-based organization with progress tracking\n"
     }
   ],
   "security": [
@@ -90,24 +93,61 @@
       "post": {
         "operationId": "createExecution",
         "summary": "createExecution",
-        "description": "Create a Workflow Execution. Start a new workflow execution, based on a workflow definition (template).",
+        "description": "Creates a new V1 Workflow Execution from a workflow definition (template).\n\n**Note:** This is the legacy V1 API. For new integrations, use `POST /v2/flows/executions` instead.\n\nThe workflow definition specifies the structure (sections and steps) of the workflow.\nWhen created, the execution instantiates all steps and begins tracking progress.\n",
         "tags": [
           "Workflow Executions"
         ],
         "requestBody": {
-          "description": "Workflow Execution payload",
+          "description": "Workflow execution creation payload with definition ID and entity contexts",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/WorkflowExecutionCreateReq"
+              },
+              "examples": {
+                "basicCreate": {
+                  "summary": "Create with single context",
+                  "description": "Create an execution linked to an opportunity entity",
+                  "value": {
+                    "workflowId": "j3f23fh23uif98",
+                    "trigger": "MANUAL",
+                    "contexts": [
+                      {
+                        "id": "3fa3fa86-0907-4642-a57e-0fe30a19874d",
+                        "title": "New Opportunity",
+                        "schema": "opportunity"
+                      }
+                    ]
+                  }
+                },
+                "automatedTrigger": {
+                  "summary": "Create from automation",
+                  "description": "Create an execution triggered automatically by an automation rule",
+                  "value": {
+                    "workflowId": "j3f23fh23uif98",
+                    "trigger": "AUTOMATIC",
+                    "contexts": [
+                      {
+                        "id": "3fa3fa86-0907-4642-a57e-0fe30a19874d",
+                        "title": "John Doe",
+                        "schema": "contact"
+                      },
+                      {
+                        "id": "3a6d42fa-5070-4723-b90f-41ead4303e33",
+                        "title": "Sales Opportunity",
+                        "schema": "opportunity"
+                      }
+                    ]
+                  }
+                }
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "Success - if the execution is created successfully",
+            "description": "Execution created successfully. Returns the complete workflow execution\nincluding all sections, steps, and initial status.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -117,31 +157,40 @@
             }
           },
           "400": {
-            "description": "Validation Errors",
+            "description": "Validation error. Common causes include:\n- Missing required workflowId\n- Invalid workflowId (definition not found)\n- Invalid context entity references\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "workflowId is required"
                 }
               }
             }
           },
           "401": {
-            "description": "Authentication Errors",
+            "description": "Authentication failed. The Bearer token is missing, expired, or invalid.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Unauthorized"
                 }
               }
             }
           },
           "500": {
-            "description": "Other errors",
+            "description": "Internal server error. An unexpected error occurred while processing the request.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Internal server error"
                 }
               }
             }
@@ -153,7 +202,7 @@
       "get": {
         "operationId": "getExecution",
         "summary": "getExecution",
-        "description": "Get a full workflow execution, included steps information, by execution id.",
+        "description": "Retrieves a complete V1 workflow execution by ID, including all steps information.\n\n**Note:** This is the legacy V1 API. For new integrations, use `GET /v2/flows/executions/{execution_id}` instead.\n",
         "tags": [
           "Workflow Executions"
         ],
@@ -356,7 +405,7 @@
       "patch": {
         "operationId": "updateStep",
         "summary": "updateStep",
-        "description": "Patches various changes to a workflow execution step.",
+        "description": "Updates a workflow execution step with new values for status, assignees, due date, position, and more.\n\n**Note:** This is the legacy V1 API. For new integrations, use `PATCH /v2/flows/executions/{execution_id}/tasks/{task_id}` instead.\n\n**Common use cases:**\n- Mark a step as completed or skipped\n- Assign or reassign users to a step\n- Update step due dates (static or dynamic)\n- Reorder steps within a section\n",
         "tags": [
           "Workflow Steps"
         ],
@@ -368,7 +417,7 @@
               "type": "string"
             },
             "required": true,
-            "description": "Id of the execution",
+            "description": "Unique identifier of the workflow execution",
             "example": "wd56125gah"
           },
           {
@@ -378,12 +427,12 @@
               "type": "string"
             },
             "required": true,
-            "description": "Short uuid (length 6) to identify the Workflow Execution Step.",
+            "description": "Short unique identifier (typically 6 characters) of the step within the execution",
             "example": "7hj28a"
           }
         ],
         "requestBody": {
-          "description": "Workflow Execution Step payload",
+          "description": "Step update payload with fields to modify",
           "required": true,
           "content": {
             "application/json": {
@@ -391,24 +440,57 @@
                 "$ref": "#/components/schemas/UpdateStepReq"
               },
               "examples": {
-                "dynamicDueDate": {
+                "markCompleted": {
+                  "summary": "Mark step as completed",
+                  "description": "Complete a step, advancing the workflow",
                   "value": {
-                    "stepId": "string",
+                    "status": "COMPLETED"
+                  }
+                },
+                "markInProgress": {
+                  "summary": "Mark step as in progress",
+                  "description": "Indicate that work has started on this step",
+                  "value": {
+                    "status": "IN_PROGRESS"
+                  }
+                },
+                "assignUsers": {
+                  "summary": "Assign users to step",
+                  "description": "Assign one or more users to the step",
+                  "value": {
                     "assignedTo": [
-                      "10010730"
-                    ],
+                      "10010730",
+                      "10010731"
+                    ]
+                  }
+                },
+                "setStaticDueDate": {
+                  "summary": "Set static due date",
+                  "description": "Set an explicit due date for the step",
+                  "value": {
+                    "dueDate": "2024-06-15T17:00:00.000Z"
+                  }
+                },
+                "setDynamicDueDate": {
+                  "summary": "Set dynamic due date",
+                  "description": "Configure due date relative to workflow start or another step",
+                  "value": {
                     "dynamicDueDate": {
                       "numberOfUnits": 2,
                       "timePeriod": "weeks",
                       "actionTypeCondition": "STEP_CLOSED",
-                      "stepId": "optional"
-                    },
-                    "name": "Static Duedate",
+                      "stepId": "abc123"
+                    }
+                  }
+                },
+                "reorderStep": {
+                  "summary": "Reorder step position",
+                  "description": "Move a step to a different position within its section",
+                  "value": {
                     "position": {
-                      "index": 0
-                    },
-                    "sectionId": "string",
-                    "status": "string"
+                      "index": 2,
+                      "sectionId": "section_abc123"
+                    }
                   }
                 }
               }
@@ -417,7 +499,7 @@
         },
         "responses": {
           "200": {
-            "description": "Success - if the step is updated successfully",
+            "description": "Step updated successfully. Returns the updated step object with all current values.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -681,24 +763,80 @@
       "post": {
         "operationId": "startFlowExecution",
         "summary": "startFlowExecution",
-        "description": "Starts a new Flow Execution based on a flow template.",
+        "description": "Starts a new Flow Execution based on a flow template (definition).\n\nThe flow template defines the structure of the workflow including phases, tasks, edges (transitions),\nand automation configurations. When started, the execution creates runtime instances of all tasks\nand begins processing from the initial task(s).\n\n**Required fields:**\n- `flow_template_id`: The ID of the flow template to instantiate\n- `contexts`: At least one entity context to link the execution to\n\n**Optional fields:**\n- `trigger`: Specifies how the execution was triggered (manual or automatic)\n- `purposes`: Filter which phases/tasks are included based on taxonomy purposes\n",
         "tags": [
           "Flows V2"
         ],
         "requestBody": {
-          "description": "Flow Execution payload",
+          "description": "Flow Execution payload containing the template ID and entity contexts",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/StartFlowReq"
+              },
+              "examples": {
+                "basicStart": {
+                  "summary": "Start with single entity context",
+                  "description": "Start a flow execution linked to an opportunity entity",
+                  "value": {
+                    "flow_template_id": "tpl_abc123def456",
+                    "contexts": [
+                      {
+                        "entity_id": "3fa3fa86-0907-4642-a57e-0fe30a19874d",
+                        "entity_schema": "opportunity",
+                        "is_primary": true
+                      }
+                    ]
+                  }
+                },
+                "multipleContexts": {
+                  "summary": "Start with multiple entity contexts",
+                  "description": "Start a flow execution linked to both a contact and an opportunity",
+                  "value": {
+                    "flow_template_id": "tpl_abc123def456",
+                    "trigger": {
+                      "type": "MANUAL"
+                    },
+                    "contexts": [
+                      {
+                        "entity_id": "3fa3fa86-0907-4642-a57e-0fe30a19874d",
+                        "entity_schema": "contact",
+                        "is_primary": true
+                      },
+                      {
+                        "entity_id": "7bc8de90-1234-5678-90ab-cdef12345678",
+                        "entity_schema": "opportunity",
+                        "is_primary": false
+                      }
+                    ]
+                  }
+                },
+                "withPurposes": {
+                  "summary": "Start with purpose filtering",
+                  "description": "Start a flow execution with specific purposes to filter applicable phases",
+                  "value": {
+                    "flow_template_id": "tpl_abc123def456",
+                    "contexts": [
+                      {
+                        "entity_id": "3fa3fa86-0907-4642-a57e-0fe30a19874d",
+                        "entity_schema": "opportunity",
+                        "is_primary": true
+                      }
+                    ],
+                    "purposes": [
+                      "sales",
+                      "onboarding"
+                    ]
+                  }
+                }
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "Success - when the flow execution is started successfully",
+            "description": "Flow execution started successfully. Returns the complete execution object including\nall phases, tasks, edges, and initial status.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -708,27 +846,53 @@
             }
           },
           "400": {
-            "description": "Validation Errors",
+            "description": "Validation error. Common causes include:\n- Missing required fields (flow_template_id, contexts)\n- Invalid flow_template_id (template not found)\n- Invalid entity context (entity not found)\n- Empty contexts array\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "flow_template_id is required"
                 }
               }
             }
           },
           "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Other errors",
+            "description": "Authentication failed. The Bearer token is missing, expired, or invalid.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access forbidden. The authenticated user does not have permission to start\nexecutions for this flow template or organization.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Forbidden"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error. An unexpected error occurred while processing the request.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Internal server error"
                 }
               }
             }
@@ -740,7 +904,7 @@
       "get": {
         "operationId": "getFlowExecution",
         "summary": "getFlowExecution",
-        "description": "Get a full flow execution, included tasks, phases, edges & analytics.",
+        "description": "Retrieves a complete flow execution by ID, including all phases, tasks, edges, contexts, and analytics.\n\nThe response includes:\n- **Execution metadata**: ID, name, status, timestamps, assignees\n- **Phases**: Organizational groupings of tasks with progress tracking\n- **Tasks**: Individual work items with their status, assignees, and configurations\n- **Edges**: Connections between tasks defining the workflow graph\n- **Analytics**: Timing information (started, completed, closed timestamps)\n- **Contexts**: Linked entity references\n",
         "tags": [
           "Flows V2"
         ],
@@ -928,7 +1092,7 @@
       "patch": {
         "operationId": "patchTask",
         "summary": "patchTask",
-        "description": "Changes various attributes of a flow task, like assignees, status, due date, etc.",
+        "description": "Updates attributes of a flow task including status, assignees, due date, and more.\n\n**Common use cases:**\n- Mark a task as completed or skipped\n- Assign or reassign users to a task\n- Update task due dates\n- Enable or disable a task\n- Revert execution to a previous task\n\n**Status transitions:**\n- `PENDING` -> `IN_PROGRESS`: User starts working on the task\n- `IN_PROGRESS` -> `COMPLETED`: User finishes the task\n- `PENDING` or `IN_PROGRESS` -> `SKIPPED`: Task is bypassed\n- `COMPLETED` or `SKIPPED` -> `PENDING`: Task is reopened (with revert_execution flag)\n\n**Reverting execution:**\nWhen updating a task that was already completed/skipped and comes before the current task,\nuse `revert_execution: true` to reset the flow back to that point. All subsequent tasks\nwill be reset to PENDING status.\n",
         "tags": [
           "Flows V2"
         ],
@@ -941,19 +1105,75 @@
           }
         ],
         "requestBody": {
-          "description": "Patch Task Payload",
+          "description": "Task update payload with fields to modify",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PatchTaskReq"
+              },
+              "examples": {
+                "markCompleted": {
+                  "summary": "Mark task as completed",
+                  "description": "Complete a task, advancing the workflow to the next task",
+                  "value": {
+                    "status": "COMPLETED"
+                  }
+                },
+                "markInProgress": {
+                  "summary": "Mark task as in progress",
+                  "description": "Indicate that work has started on this task",
+                  "value": {
+                    "status": "IN_PROGRESS"
+                  }
+                },
+                "skipTask": {
+                  "summary": "Skip a task",
+                  "description": "Bypass a task without completing it",
+                  "value": {
+                    "status": "SKIPPED"
+                  }
+                },
+                "assignUsers": {
+                  "summary": "Assign users to task",
+                  "description": "Assign one or more users to be responsible for this task",
+                  "value": {
+                    "assigned_to": [
+                      "10010730",
+                      "10010731"
+                    ]
+                  }
+                },
+                "updateDueDate": {
+                  "summary": "Set task due date",
+                  "description": "Set an explicit due date for the task",
+                  "value": {
+                    "due_date": "2024-06-15T17:00:00.000Z"
+                  }
+                },
+                "revertToPreviousTask": {
+                  "summary": "Revert execution to previous task",
+                  "description": "Reset workflow back to a previously completed task, clearing all subsequent progress",
+                  "value": {
+                    "status": "PENDING",
+                    "revert_execution": true
+                  }
+                },
+                "decisionTaskBranch": {
+                  "summary": "Select branch for decision task",
+                  "description": "For manual decision tasks, specify which condition/branch to follow",
+                  "value": {
+                    "status": "COMPLETED",
+                    "next_condition_id": "cond_branch_a"
+                  }
+                }
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Success - when task has been successfully updated",
+            "description": "Task updated successfully. Returns the updated task object with all current values.\nIf the status change triggers workflow advancement, the flow execution state is also updated.\n",
             "content": {
               "application/json": {
                 "schema": {
@@ -963,31 +1183,53 @@
             }
           },
           "400": {
-            "description": "Validation Errors",
+            "description": "Validation error. Common causes include:\n- Invalid status transition (e.g., COMPLETED to IN_PROGRESS without revert)\n- Invalid task_id\n- Invalid assigned_to user IDs\n- Invalid due_date format\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Invalid status transition from COMPLETED to IN_PROGRESS"
                 }
               }
             }
           },
           "401": {
-            "description": "Authentication Errors",
+            "description": "Authentication failed. The Bearer token is missing, expired, or invalid.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Unauthorized"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Task or execution not found. The specified execution_id or task_id does not exist.\n",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Task not found"
                 }
               }
             }
           },
           "500": {
-            "description": "Other errors",
+            "description": "Internal server error. An unexpected error occurred while processing the request.\n",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ErrorResp"
+                },
+                "example": {
+                  "message": "Internal server error"
                 }
               }
             }
@@ -1034,6 +1276,96 @@
           },
           "401": {
             "description": "Authentication Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Other errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/flows/executions/{execution_id}/tasks/{task_id}/agent:run": {
+      "post": {
+        "operationId": "runTaskAgent",
+        "summary": "runTaskAgent",
+        "description": "Dispatches the configured AI agent for a flow task. Used when the task's trigger_mode is 'manual', so the agent only runs after an explicit user action.",
+        "tags": [
+          "Flows V2"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/ExecutionIdParam"
+          },
+          {
+            "$ref": "#/components/parameters/TaskIdParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success - when the AI agent has been successfully dispatched",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AiAgentTask"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation Errors - task is not an AI agent task, agent_id missing, or invalid ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication Errors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - user lacks UpdateTaskStatus permission or AI agent flows are not enabled for the organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Flow execution not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResp"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict - AI agent task has already been dispatched",
             "content": {
               "application/json": {
                 "schema": {
@@ -1468,8 +1800,8 @@
           "type": "string"
         },
         "required": true,
-        "description": "Id of the execution",
-        "example": "wd561"
+        "description": "Unique identifier for the flow execution. This ID is generated when the execution\nis created and remains constant throughout its lifecycle.\n",
+        "example": "exec_abc123def456"
       },
       "TaskIdParam": {
         "in": "path",
@@ -1478,8 +1810,8 @@
           "type": "string"
         },
         "required": true,
-        "description": "Id of the task",
-        "example": "7hj28a"
+        "description": "Unique identifier for a task within the execution. Each task has a unique ID\nthat distinguishes it from other tasks in the same execution.\n",
+        "example": "task_7hj28a"
       },
       "PhaseIdParam": {
         "in": "path",
@@ -1488,8 +1820,8 @@
           "type": "string"
         },
         "required": true,
-        "description": "Id of the phase",
-        "example": "9gjs2952j"
+        "description": "Unique identifier for a phase within the execution. Phases group related tasks\ntogether and track collective progress.\n",
+        "example": "phase_9gjs2952j"
       },
       "ScheduleIdParam": {
         "in": "path",
@@ -1498,7 +1830,7 @@
           "type": "string"
         },
         "required": true,
-        "description": "Id of the schedule",
+        "description": "Unique identifier for a scheduled task action. Schedules are created when tasks\nare configured with delayed or relative timing.\n",
         "example": "sch_8k2m9n4p"
       },
       "SoftDeleteParam": {
@@ -1509,7 +1841,7 @@
           "default": false
         },
         "required": false,
-        "description": "If true, the execution will NOT be deleted permanently, but rather kept for archive purpose.",
+        "description": "When true, the execution is marked as deleted but retained in storage for archival\nand audit purposes. When false (default), the execution is permanently removed.\nSoft-deleted executions do not appear in normal queries.\n",
         "example": true
       }
     },
@@ -2606,11 +2938,17 @@
       },
       "ErrorResp": {
         "type": "object",
+        "description": "Standard error response returned when an API request fails.\nContains a human-readable message describing the error.\n",
         "properties": {
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Human-readable description of the error that occurred",
+            "example": "Validation failed: workflowId is required"
           }
-        }
+        },
+        "required": [
+          "message"
+        ]
       },
       "ClosingReasonResp": {
         "type": "object",
@@ -2944,19 +3282,23 @@
       },
       "StartFlowReq": {
         "type": "object",
+        "description": "Request payload for starting a new flow execution from a template.\n",
         "required": [
           "flow_template_id",
           "contexts"
         ],
         "properties": {
           "flow_template_id": {
-            "type": "string"
+            "type": "string",
+            "description": "The unique identifier of the flow template (definition) to instantiate.\nThe template must exist and be accessible within the organization.\n",
+            "example": "tpl_abc123def456"
           },
           "trigger": {
             "$ref": "#/components/schemas/FlowTrigger"
           },
           "contexts": {
             "type": "array",
+            "description": "Entity references that this execution is linked to. At least one context\nis required. The primary context (is_primary: true) is used for condition\nevaluation and data mapping.\n",
             "minItems": 1,
             "items": {
               "$ref": "#/components/schemas/FlowContext"
@@ -2967,7 +3309,7 @@
             "items": {
               "type": "string"
             },
-            "description": "An array of purposes to filter workflow phases."
+            "description": "Taxonomy purpose IDs to filter which phases and tasks are included in the execution.\nOnly phases/tasks tagged with matching purposes will be active. If empty or omitted,\nall phases and tasks from the template are included.\n"
           }
         }
       },
@@ -3101,6 +3443,11 @@
               "properties": {
                 "id": {
                   "$ref": "#/components/schemas/TaskId"
+                },
+                "crt_since": {
+                  "type": "string",
+                  "format": "date-time",
+                  "description": "Timestamp when this task entered crt_tasks (i.e. became current). Used by the flow-healing-service as the authoritative gate for \"has this PENDING task been stuck long enough to heal?\". Using the task's own analytics.status_updated_at as the gate produced false positives because transitioning a task INTO crt_tasks does not change its status — so that timestamp can be hours old for a freshly-current task."
                 }
               }
             }
@@ -3540,6 +3887,9 @@
               "agent_execution_id": {
                 "type": "string",
                 "description": "ID of the agent execution, used for tracking status updates. This is needed as a separate field to allow indexing."
+              },
+              "trigger_mode": {
+                "$ref": "#/components/schemas/TriggerMode"
               }
             }
           }
@@ -3767,6 +4117,15 @@
           },
           "input_context": {
             "$ref": "#/components/schemas/AutomationInputContext"
+          },
+          "heal_attempts": {
+            "type": "integer",
+            "description": "Internal — number of times flow-healing-service has attempted to re-trigger this task's lost automation dispatch. Used to cap retries and avoid an indefinite heal-on-every-read storm against a deterministically-failing automation flow."
+          },
+          "last_heal_attempted_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Internal — timestamp of the most recent heal attempt for this task. flow-healing-service uses this as a per-task debounce gate so the heal cannot fire more than once per HEAL_RETRY_COOLDOWN_MS regardless of how often the flow execution is read."
           }
         },
         "required": [
@@ -3978,6 +4337,22 @@
               "deleted"
             ]
           },
+          "attributes": {
+            "type": "array",
+            "maxItems": 10,
+            "items": {
+              "type": "string"
+            },
+            "description": "Multi-attribute mode. When present and length > 1, the statement is\nevaluated against every listed attribute and combined via\n`attributes_match`. All listed attributes must share the same\n`attribute_type`. Mutually exclusive with `attribute_sub_field`,\n`date_offset`, and `attribute_operation`. When absent or length === 1,\nthe legacy `attribute` field is used.\n"
+          },
+          "attributes_match": {
+            "type": "string",
+            "enum": [
+              "any",
+              "all"
+            ],
+            "description": "Inner connector across `attributes`. `any` (default) means at least\none attribute must satisfy the operator; `all` means every attribute\nmust satisfy it. Ignored when `attributes` is absent or has length < 2.\n"
+          },
           "attribute_sub_field": {
             "type": "string",
             "description": "For complex attribute types, specifies which sub-field to extract (e.g., 'address', 'name', 'email_type')"
@@ -4062,7 +4437,8 @@
           "hours",
           "days",
           "weeks",
-          "months"
+          "months",
+          "years"
         ]
       },
       "EnableRequirement": {
@@ -4139,16 +4515,20 @@
       },
       "PatchTaskReq": {
         "type": "object",
+        "description": "Request payload for updating a task within a flow execution.\nAll fields are optional; only provided fields will be updated.\n",
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "description": "Display name of the task",
+            "example": "Review customer application"
           },
           "status": {
             "$ref": "#/components/schemas/StepStatus"
           },
           "due_date": {
             "type": "string",
-            "example": "2021-04-27T12:00:00.000Z"
+            "description": "Explicit due date for the task. Takes precedence over\ndue_date_config if both are provided.\n\nNote: intentionally typed as plain `string` (not\n`format: date-time`). For day/week/month-precision due\ndates the server stores a \"floating\" datetime without a\ntimezone designator (e.g. `2026-05-28T00:00:00.000`) so\nthat the UI can render it as a date in the user's local\ntimezone without shifting the displayed day. Tightening\nthis to `format: date-time` causes openapi-zod-client to\nemit `z.string().datetime({ offset: true })` in\n`validators-generated.ts`, which then trips\n`safeParse(body)` in `patch-task.ts` whenever the\nsidebar sends a stored task back with a tz-less\n`due_date`. See commit 4aca299c (Aug 2024) for the\noriginal date-only display rationale and the May 2026\nincident (513ed597 added the format, ee574b43\nunintentionally activated it via an unrelated regen) for\nthe history. Long-term, day-precision due dates should\nmigrate to a separate `format: date` field.\n",
+            "example": "2026-05-28T00:00:00.000"
           },
           "due_date_config": {
             "$ref": "#/components/schemas/DueDateConfig"
@@ -4158,7 +4538,7 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "flag for controlling enabled/disabled state of the task"
+            "description": "Controls whether the task is enabled (can be worked on) or disabled (grayed out).\nDisabled tasks cannot have their status changed until re-enabled.\n"
           },
           "automation_config": {
             "$ref": "#/components/schemas/AutomationInfo"
@@ -4178,11 +4558,12 @@
           },
           "next_condition_id": {
             "type": "string",
-            "description": "Condition to evaluate as true for a decision task with a manual trigger mode"
+            "description": "For decision tasks with manual trigger mode, specifies which condition/branch\nto follow when completing the task. The condition ID must match one of the\nconditions defined on the decision task.\n",
+            "example": "cond_branch_approved"
           },
           "revert_execution": {
             "type": "boolean",
-            "description": "When patching an already completed/skipped task that comes before the current task, this flag controls whether to revert the execution:\n- `true`: The patched task becomes the current task AND all succeeding tasks are reset to PENDING (full revert)\n- `false` or omitted (undefined): The task is updated but the current task does not change and no downstream tasks are affected\nThis parameter is silently ignored when patching the current task or future tasks.\n",
+            "description": "Controls behavior when updating a task that was already completed/skipped and\ncomes before the current task in the workflow:\n- `true`: Reverts the execution - the patched task becomes the current task\n  and all subsequent tasks are reset to PENDING status\n- `false` (default): Updates only this task without affecting workflow position\n  or other tasks\n\n**Important:** This parameter is silently ignored when:\n- Patching the current task\n- Patching future tasks (tasks that haven't been reached yet)\n",
             "default": false
           }
         }


### PR DESCRIPTION
## Summary

Regenerate `@epilot/workflow-client` from the updated `svc-workflows-execution` openapi to surface the new `runTaskAgent` endpoint and the `trigger_mode` field on `AiAgentTask`.

This is the SDK companion for a multi-repo fix: AI Agent tasks in Flows v2/v3 were ignoring the builder's "Start task automatically" toggle and always running as soon as they became current. With this SDK change, the runtime UI (`epilot360-workflows-execution`) can call the new typed `wfClient.runTaskAgent({ execution_id, task_id })` method for the manual-trigger Run button.

## Changes

- Regenerated `src/openapi.json`, `src/openapi-runtime.json`, and `src/openapi.d.ts` from the local svc-workflows-execution spec.
- New operation: `runTaskAgent` → `POST /v2/flows/executions/{execution_id}/tasks/{task_id}/agent:run`. Returns `AiAgentTask`. Documented response codes: 200, 400, 401, 403, 404, 409, 500.
- `AiAgentTask` now exposes optional `trigger_mode` (`'manual' | 'automatic'`), mirroring `AutomationTask`. Undefined is treated as automatic by the backend (no data migration required).

## Changeset

A `.changeset/workflow-client-run-task-agent.md` entry requests a `minor` bump for `@epilot/workflow-client` (currently 1.23.1).

## Test plan

- [x] `pnpm openapi <local-spec>` regenerated cleanly.
- [x] `pnpm typegen` clean.
- [x] `pnpm build` clean.
- [x] `pnpm test` passes (3/3).
- [x] `grep -n "runTaskAgent\|trigger_mode" src/openapi.d.ts` confirms surface.

## Companion MRs

- svc-workflows (backend): https://gitlab.com/e-pilot/product/workflow/svc-workflows/-/merge_requests/757
- epilot360-workflows-hub (builder): https://gitlab.com/e-pilot/product/workflow/epilot360-workflows-hub/-/merge_requests/708
- epilot360-workflows-execution (runtime UI): blocked on this SDK being published, then will land.

## Note for reviewer

The runtime UI MR is blocked on this SDK being merged AND published to npm via `pnpm publish-packages`. Please review/merge here, then publish - the workflows-execution MR will follow once the new version is consumable.
