### PR TITLE
feat(targeting-client): add `from` offset param to getRecipients

### DIFF
--- a/.changeset/targeting-recipients-from-offset.md
+++ b/.changeset/targeting-recipients-from-offset.md
@@ -1,0 +1,7 @@
+---
+"@epilot/targeting-client": minor
+---
+
+Add `from` offset parameter to `getRecipients`
+
+- `getRecipients` (`GET /v1/campaign/{campaign_id}/recipients`) now accepts an optional `from` query parameter — a zero-based offset of the first item to return. This enables direct (random-access) pagination to any page in a single request, instead of walking `next` cursors page by page. When `from` is provided it takes precedence over `next`.

--- a/clients/targeting-client/src/openapi.json
+++ b/clients/targeting-client/src/openapi.json
@@ -479,9 +479,19 @@
           {
             "name": "next",
             "in": "query",
-            "description": "Cursor for pagination",
+            "description": "Cursor for sequential pagination. Ignored when `from` is provided.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Zero-based offset of the first item to return. Enables direct (random-access) pagination to any page. When provided, it takes precedence over `next`.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
             }
           },
           {
@@ -1313,7 +1323,7 @@
               },
               "target_ids": {
                 "type": "array",
-                "description": "List of target entity IDs to attach to the campaign. Today only a single\nentry is supported (campaign.target is has_one) but the array shape is kept\nfor forward-compatibility — only `target_ids[0]` is used.\n",
+                "description": "List of target entity IDs to attach to the campaign. Today only a single\nentry is supported (campaign.target is has_one) but the array shape is kept\nfor forward-compatibility \u2014 only `target_ids[0]` is used.\n",
                 "items": {
                   "$ref": "#/components/schemas/BaseUUID"
                 }

--- a/packages/epilot-sdk-v2/src/definitions/targeting.json
+++ b/packages/epilot-sdk-v2/src/definitions/targeting.json
@@ -428,9 +428,19 @@
           {
             "name": "next",
             "in": "query",
-            "description": "Cursor for pagination",
+            "description": "Cursor for sequential pagination. Ignored when `from` is provided.",
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Zero-based offset of the first item to return. Enables direct (random-access) pagination to any page. When provided, it takes precedence over `next`.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
             }
           },
           {


### PR DESCRIPTION
Add an optional zero-based `from` query parameter to getRecipients enabling direct (random-access) pagination to any page in a single request. When provided it takes precedence over the `next` cursor.

Generated artifacts are produced from these specs by the SDK build; a changeset is included for the release.