### PR TITLE
feat(cli): show read-only status and add --readonly login flag

### DIFF
--- a/packages/cli/src/commands/auth-login.ts
+++ b/packages/cli/src/commands/auth-login.ts
@@ -10,12 +10,14 @@ export default defineCommand({
   args: {
     token: { type: 'string', description: 'Manually provide a token instead of browser login' },
     profile: { type: 'string', description: 'Save credentials to this profile' },
+    readonly: { type: 'boolean', description: 'Generate a read-only token (cannot perform write actions)' },
     'use-dev': { type: 'boolean', description: 'Use dev environment (portal.dev.epilot.cloud)' },
     'use-staging': { type: 'boolean', description: 'Use staging environment (portal.staging.epilot.cloud)' },
   },
   run: async ({ args }) => {
     const profileName = args.profile || process.env.EPILOT_PROFILE;
     const env = resolveEnvironment(args['use-dev'], args['use-staging']);
+    const readonly = Boolean(args.readonly);
 
     // Manual token input
     if (args.token) {
@@ -33,7 +35,7 @@ export default defineCommand({
       process.exit(1);
     }
 
-    const token = await browserLogin(profileName, env);
+    const token = await browserLogin(profileName, env, readonly);
     if (token) {
       process.stdout.write(`${GREEN}${BOLD}Login successful!${RESET}\n`);
     } else {
@@ -43,7 +45,11 @@ export default defineCommand({
   },
 });
 
-const browserLogin = async (profileName?: string, env: Environment = 'production'): Promise<string | null> => {
+const browserLogin = async (
+  profileName?: string,
+  env: Environment = 'production',
+  readonly = false,
+): Promise<string | null> => {
   // Generate a cryptographic state parameter to prevent CSRF
   const state = randomBytes(32).toString('hex');
 
@@ -54,6 +60,11 @@ const browserLogin = async (profileName?: string, env: Environment = 'production
   const suffix = profileName ? ` ${DIM}(profile: ${profileName})${RESET}` : '';
   process.stdout.write(`\n${BOLD}epilot CLI Login${RESET}${suffix}\n\n`);
   process.stdout.write('This will open your browser to authenticate with epilot.\n');
+  if (readonly) {
+    process.stdout.write(
+      `${YELLOW}Read-only mode: the CLI session will not be able to perform write actions.${RESET}\n`,
+    );
+  }
   process.stdout.write('\n');
   process.stdout.write(`  ${YELLOW}Verification code: ${BOLD}${verificationCode}${RESET}\n`);
   process.stdout.write('\n');
@@ -99,7 +110,8 @@ const browserLogin = async (profileName?: string, env: Environment = 'production
       const loginUrl =
         `${portalUrl}/login?cli_callback=${encodeURIComponent(callbackUrl)}` +
         `&state=${state}` +
-        `&code=${verificationCode}`;
+        `&code=${verificationCode}` +
+        (readonly ? `&readonly=true` : '');
 
       process.stdout.write(`\n${DIM}Login URL: ${loginUrl}${RESET}\n\n`);
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -48,6 +48,7 @@ export default defineCommand({
         const adminEmail = claims?.admin_email as string | undefined;
         const tokenUse = claims?.token_use as string | undefined;
         const roles = claims?.assume_roles as string[] | undefined;
+        const readOnly = claims?.read_only === true;
 
         if (name) process.stdout.write(`  Name:    ${name}\n`);
         if (adminEmail && adminEmail !== name) process.stdout.write(`  Email:   ${adminEmail}\n`);
@@ -56,6 +57,7 @@ export default defineCommand({
         if (tokenId && tokenId !== userId) process.stdout.write(`  Token ID: ${tokenId}\n`);
         if (tokenUse) process.stdout.write(`  Use:     ${tokenUse}\n`);
         if (roles?.length) process.stdout.write(`  Roles:   ${roles.join(', ')}\n`);
+        process.stdout.write(`  Access:  ${readOnly ? `${YELLOW}read-only${RESET}` : `${GREEN}read-write${RESET}`}\n`);
 
         // Expiry
         if (creds.expires_at) {


### PR DESCRIPTION
## What

Two changes to the `epilot` CLI auth commands, building on the access token API's new read-only token support (`read_only` JWT claim).

### `epilot auth status`
Adds an **Access** line that shows whether the current token is `read-only` (yellow) or `read-write` (green), derived from the `read_only` claim.

### `epilot auth login --readonly`
New `--readonly` flag. When set, the CLI:
- prints a note that the session will be read-only,
- appends `readonly=true` to the portal login URL.

The portal authorize page reads that param to pre-check and lock the "Read-only mode" checkbox, then mints a read-only token (see the companion epilot360-login MR). Without the flag, the user can still opt into read-only via the checkbox in the browser.

## Companion changes
- **epilot360-login**: read-only checkbox on the CLI authorize page + token minting.
- **access-token-api**: allows non-owners to mint `assume` tokens carrying exactly their own roles (required so non-owner users can obtain a read-only session).

## Testing
- `vitest run` — 100 passing
- `auth login --help` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vLMc3q4Rb1onmpQXoGDBa
