### PR TITLE
chore(targeting-client): regen for campaign:discover + entity_ui:status

### DIFF
--- a/clients/targeting-client/package.json
+++ b/clients/targeting-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/targeting-client",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "JavaScript client library for the epilot Targeting API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/targeting-client/src/openapi-runtime.json
+++ b/clients/targeting-client/src/openapi-runtime.json
@@ -84,6 +84,18 @@
         "responses": {}
       }
     },
+    "/v1/campaign:discover": {
+      "post": {
+        "operationId": "discoverCampaigns",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      }
+    },
     "/v1/target:match": {
       "post": {
         "operationId": "matchTargets",
@@ -148,6 +160,26 @@
     "/v1/campaign/{campaign_id}/recipient/{recipient_id}/portal:status": {
       "patch": {
         "operationId": "updateRecipientPortalStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CampaignIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/RecipientIdPathParam"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      }
+    },
+    "/v1/campaign/{campaign_id}/recipient/{recipient_id}/entity_ui:status": {
+      "patch": {
+        "operationId": "updateRecipientEntityUiStatus",
         "parameters": [
           {
             "$ref": "#/components/parameters/CampaignIdPathParam"
@@ -244,6 +276,11 @@
         }
       },
       "MatchCampaignsResponse": {
+        "content": {
+          "application/json": {}
+        }
+      },
+      "DiscoverCampaignsResponse": {
         "content": {
           "application/json": {}
         }

--- a/clients/targeting-client/src/openapi.d.ts
+++ b/clients/targeting-client/src/openapi.d.ts
@@ -68,6 +68,38 @@ declare namespace Components {
          *
          */
         Schemas.ClientError;
+        export interface DiscoverCampaignsResponse {
+            /**
+             * Number of matching NBAs.
+             */
+            hits: number;
+            /**
+             * Matching NBAs, sorted by priority (desc); one entry per campaign.
+             */
+            results: {
+                campaign_id: /**
+                 * example:
+                 * b8c01433-5556-4e2b-aad4-6f5348d1df84
+                 */
+                Schemas.BaseUUID /* uuid */;
+                nba: /**
+                 * A Next Best Action configured on a campaign's Entity-UI channel.
+                 * This is the canonical NBA contract shared by discovery (this API), authoring, and rendering.
+                 * NBA content is single-language in v1; text fields may contain `{{placeholders}}` resolved at render time.
+                 *
+                 */
+                Schemas.NextBestAction;
+                /**
+                 * The recipient's current Entity-UI status for this campaign, present only
+                 * when a recipient record already exists (i.e. the entity has previously seen
+                 * or clicked this NBA). Absent when the entity has not yet interacted with it.
+                 * Dismissed NBAs are filtered out server-side, so this is only ever `seen` or
+                 * `clicked`. Lets the client skip a redundant `seen` call for NBAs already seen.
+                 *
+                 */
+                status?: "seen" | "dismissed" | "clicked";
+            }[];
+        }
         export interface GetTargetQueriesResponse {
             /**
              * List of target query results.
@@ -342,6 +374,24 @@ declare namespace Components {
                 [name: string]: any;
             };
         };
+        export interface DiscoverCampaignsParams {
+            entity_id: /**
+             * example:
+             * b8c01433-5556-4e2b-aad4-6f5348d1df84
+             */
+            BaseUUID /* uuid */;
+            /**
+             * The schema slug of the entity (e.g. "contact" or "account").
+             */
+            entity_schema: string;
+        }
+        /**
+         * Lifecycle status of a Next Best Action on the Entity-UI channel. Unlike the portal
+         * channel there is no `sent` state: an NBA recipient is born at `seen`, the moment the
+         * action is first rendered to an agent.
+         *
+         */
+        export type EntityUiStatus = "seen" | "dismissed" | "clicked";
         export interface ExecutionSummaryItem {
             execution_id?: string;
             execution_status?: string;
@@ -1418,6 +1468,71 @@ declare namespace Components {
                 BaseUUID /* uuid */?
             ];
         }
+        /**
+         * A Next Best Action configured on a campaign's Entity-UI channel.
+         * This is the canonical NBA contract shared by discovery (this API), authoring, and rendering.
+         * NBA content is single-language in v1; text fields may contain `{{placeholders}}` resolved at render time.
+         *
+         */
+        export interface NextBestAction {
+            /**
+             * Light category label shown above the title. Free-form text.
+             */
+            category?: string;
+            /**
+             * Curated icon for the NBA.
+             */
+            icon?: {
+                /**
+                 * Icon name from "@epilot360/icons".
+                 */
+                name: string;
+                /**
+                 * Optional icon color.
+                 */
+                color?: string;
+            };
+            /**
+             * Bold action title. Required. Supports `{{placeholders}}`.
+             */
+            title: string;
+            /**
+             * Optional description. Supports `{{placeholders}}` (incl. relative dates).
+             */
+            body?: string;
+            /**
+             * Display priority. NBAs are shown highest-priority first.
+             */
+            priority?: "low" | "medium" | "high";
+            /**
+             * Whether the agent can dismiss the NBA.
+             */
+            is_dismissable?: boolean;
+            /**
+             * The NBA's single call-to-action.
+             */
+            cta: {
+                type: "journey" | "workflow" | "url";
+                /**
+                 * Journey id, workflow definition id, or URL, depending on `type`.
+                 */
+                target: string;
+                /**
+                 * Optional CTA button label.
+                 */
+                label?: string;
+                /**
+                 * Journey context parameters (journey CTA only). Maps the journey's declared
+                 * context parameters so the journey knows which entity it is about. Discovery
+                 * returns them verbatim; they are passed to the journey when it launches.
+                 *
+                 */
+                context_params?: {
+                    key: string;
+                    value: string;
+                }[];
+            };
+        }
         export interface PortalRecipientPayload {
             portal_status: PortalStatus;
             portal_state?: {
@@ -1440,8 +1555,32 @@ declare namespace Components {
             portal_state?: {
                 [name: string]: any;
             };
+            entity_ui_status?: /**
+             * Lifecycle status of a Next Best Action on the Entity-UI channel. Unlike the portal
+             * channel there is no `sent` state: an NBA recipient is born at `seen`, the moment the
+             * action is first rendered to an agent.
+             *
+             */
+            EntityUiStatus;
+            entity_ui_status_updated_at?: string; // date-time
+            resolution?: /**
+             * Cross-channel resolution of a campaign for a recipient. Unlike the per-channel `*_status`
+             * fields (where `dismissed` is channel-local), a resolution suppresses the campaign on EVERY
+             * channel — the 360 Entity-UI card and the portal teaser alike. Server-managed and read-only:
+             * never sent by a client. Absence means unresolved.
+             *
+             */
+            Resolution;
             updated_at?: string; // date-time
         }
+        /**
+         * Cross-channel resolution of a campaign for a recipient. Unlike the per-channel `*_status`
+         * fields (where `dismissed` is channel-local), a resolution suppresses the campaign on EVERY
+         * channel — the 360 Entity-UI card and the portal teaser alike. Server-managed and read-only:
+         * never sent by a client. Absence means unresolved.
+         *
+         */
+        export type Resolution = "accepted";
         export interface RetriggerAutomationsRequest {
             /**
              * List of recipient IDs to retrigger automations for
@@ -1672,6 +1811,21 @@ declare namespace Components {
              */
             error?: string;
         }
+        export interface UpdateEntityUiStatusRequest {
+            status: /**
+             * Lifecycle status of a Next Best Action on the Entity-UI channel. Unlike the portal
+             * channel there is no `sent` state: an NBA recipient is born at `seen`, the moment the
+             * action is first rendered to an agent.
+             *
+             */
+            EntityUiStatus;
+            /**
+             * Schema slug of the recipient entity (e.g. "contact"). Required when recording the
+             * first `seen`, which lazily creates the recipient record; ignored on later transitions.
+             *
+             */
+            entity_schema?: string;
+        }
         export interface UpdatePortalStatusRequest {
             status: PortalStatus;
         }
@@ -1717,6 +1871,14 @@ declare namespace Paths {
         export type RequestBody = Components.Schemas.CreateRecipientPayload;
         namespace Responses {
             export type $201 = Components.Responses.RecipientResponse;
+            export type $400 = Components.Responses.ClientErrorResponse;
+            export type $500 = Components.Responses.ServerErrorResponse;
+        }
+    }
+    namespace DiscoverCampaigns {
+        export type RequestBody = Components.Schemas.DiscoverCampaignsParams;
+        namespace Responses {
+            export type $200 = Components.Responses.DiscoverCampaignsResponse;
             export type $400 = Components.Responses.ClientErrorResponse;
             export type $500 = Components.Responses.ServerErrorResponse;
         }
@@ -1864,6 +2026,32 @@ declare namespace Paths {
             export type $500 = Components.Responses.ServerErrorResponse;
         }
     }
+    namespace UpdateRecipientEntityUiStatus {
+        namespace Parameters {
+            export type CampaignId = /**
+             * example:
+             * b8c01433-5556-4e2b-aad4-6f5348d1df84
+             */
+            Components.Schemas.BaseUUID /* uuid */;
+            export type RecipientId = /**
+             * example:
+             * b8c01433-5556-4e2b-aad4-6f5348d1df84
+             */
+            Components.Schemas.BaseUUID /* uuid */;
+        }
+        export interface PathParameters {
+            campaign_id: Parameters.CampaignId;
+            recipient_id: Parameters.RecipientId;
+        }
+        export type RequestBody = Components.Schemas.UpdateEntityUiStatusRequest;
+        namespace Responses {
+            export type $200 = Components.Responses.RecipientResponse;
+            export type $400 = Components.Responses.ClientErrorResponse;
+            export type $404 = Components.Responses.ClientErrorResponse;
+            export type $409 = Components.Responses.ClientErrorResponse;
+            export type $500 = Components.Responses.ServerErrorResponse;
+        }
+    }
     namespace UpdateRecipientPortalStatus {
         namespace Parameters {
             export type CampaignId = /**
@@ -1973,6 +2161,24 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.MatchCampaigns.Responses.$200>
   /**
+   * discoverCampaigns - Discover Entity-UI Next Best Actions for an entity
+   * 
+   * Given an entity, returns the Next Best Actions it should see on the Entity-UI channel.
+   * 
+   * Enumerates the organization's **active** campaigns that carry a valid Entity-UI Next Best
+   * Action, live-matches each against the entity using the existing match engine, and returns
+   * the matching NBAs priority-sorted (one per campaign).
+   * 
+   * This is a pure read: it writes nothing. An entity that matches no campaigns returns an
+   * empty list, not an error.
+   * 
+   */
+  'discoverCampaigns'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.DiscoverCampaigns.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.DiscoverCampaigns.Responses.$200>
+  /**
    * matchTargets - Match targets
    * 
    * Find targets from the provided list that include the provide entities.
@@ -2032,6 +2238,32 @@ export interface OperationMethods {
     data?: Paths.UpdateRecipientPortalStatus.RequestBody,
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.UpdateRecipientPortalStatus.Responses.$200>
+  /**
+   * updateRecipientEntityUiStatus - Update Entity-UI (Next Best Action) status for a campaign recipient
+   * 
+   * Records a Next Best Action interaction for a recipient on the Entity-UI channel.
+   * 
+   * Unlike the portal channel, an NBA recipient is created lazily: the first `seen` creates
+   * the recipient record (and requires `entity_schema`). `seen` is idempotent — re-viewing an
+   * NBA that is already seen/clicked/dismissed is a no-op success and never regresses the status.
+   * 
+   * Status transition rules:
+   * - `seen`: lazily creates the recipient; a no-op success if a status already exists
+   * - From `seen`: can change to `clicked` or `dismissed`
+   * - From `clicked`: can change to `dismissed`
+   * - From `dismissed`: cannot be changed (final state)
+   * 
+   * `dismissed` and `clicked` require an existing recipient (404 otherwise, since an NBA is
+   * born at `seen`) and reject invalid transitions (409).
+   * 
+   * The entity_ui_status_updated_at timestamp is automatically set when the status changes.
+   * 
+   */
+  'updateRecipientEntityUiStatus'(
+    parameters?: Parameters<Paths.UpdateRecipientEntityUiStatus.PathParameters> | null,
+    data?: Paths.UpdateRecipientEntityUiStatus.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.UpdateRecipientEntityUiStatus.Responses.$200>
   /**
    * getRecipients - Get campaign recipients
    * 
@@ -2135,6 +2367,26 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.MatchCampaigns.Responses.$200>
   }
+  ['/v1/campaign:discover']: {
+    /**
+     * discoverCampaigns - Discover Entity-UI Next Best Actions for an entity
+     * 
+     * Given an entity, returns the Next Best Actions it should see on the Entity-UI channel.
+     * 
+     * Enumerates the organization's **active** campaigns that carry a valid Entity-UI Next Best
+     * Action, live-matches each against the entity using the existing match engine, and returns
+     * the matching NBAs priority-sorted (one per campaign).
+     * 
+     * This is a pure read: it writes nothing. An entity that matches no campaigns returns an
+     * empty list, not an error.
+     * 
+     */
+    'post'(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.DiscoverCampaigns.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.DiscoverCampaigns.Responses.$200>
+  }
   ['/v1/target:match']: {
     /**
      * matchTargets - Match targets
@@ -2205,6 +2457,34 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.UpdateRecipientPortalStatus.Responses.$200>
   }
+  ['/v1/campaign/{campaign_id}/recipient/{recipient_id}/entity_ui:status']: {
+    /**
+     * updateRecipientEntityUiStatus - Update Entity-UI (Next Best Action) status for a campaign recipient
+     * 
+     * Records a Next Best Action interaction for a recipient on the Entity-UI channel.
+     * 
+     * Unlike the portal channel, an NBA recipient is created lazily: the first `seen` creates
+     * the recipient record (and requires `entity_schema`). `seen` is idempotent — re-viewing an
+     * NBA that is already seen/clicked/dismissed is a no-op success and never regresses the status.
+     * 
+     * Status transition rules:
+     * - `seen`: lazily creates the recipient; a no-op success if a status already exists
+     * - From `seen`: can change to `clicked` or `dismissed`
+     * - From `clicked`: can change to `dismissed`
+     * - From `dismissed`: cannot be changed (final state)
+     * 
+     * `dismissed` and `clicked` require an existing recipient (404 otherwise, since an NBA is
+     * born at `seen`) and reject invalid transitions (409).
+     * 
+     * The entity_ui_status_updated_at timestamp is automatically set when the status changes.
+     * 
+     */
+    'patch'(
+      parameters?: Parameters<Paths.UpdateRecipientEntityUiStatus.PathParameters> | null,
+      data?: Paths.UpdateRecipientEntityUiStatus.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.UpdateRecipientEntityUiStatus.Responses.$200>
+  }
   ['/v1/campaign/{campaign_id}/recipients']: {
     /**
      * getRecipients - Get campaign recipients
@@ -2239,14 +2519,18 @@ export type Campaign = Components.Schemas.Campaign;
 export type CampaignStatus = Components.Schemas.CampaignStatus;
 export type ClientError = Components.Schemas.ClientError;
 export type CreateRecipientPayload = Components.Schemas.CreateRecipientPayload;
+export type DiscoverCampaignsParams = Components.Schemas.DiscoverCampaignsParams;
+export type EntityUiStatus = Components.Schemas.EntityUiStatus;
 export type ExecutionSummaryItem = Components.Schemas.ExecutionSummaryItem;
 export type GetTargetQueriesParams = Components.Schemas.GetTargetQueriesParams;
 export type JobStatus = Components.Schemas.JobStatus;
 export type MatchCampaignParams = Components.Schemas.MatchCampaignParams;
 export type MatchTargetParams = Components.Schemas.MatchTargetParams;
+export type NextBestAction = Components.Schemas.NextBestAction;
 export type PortalRecipientPayload = Components.Schemas.PortalRecipientPayload;
 export type PortalStatus = Components.Schemas.PortalStatus;
 export type Recipient = Components.Schemas.Recipient;
+export type Resolution = Components.Schemas.Resolution;
 export type RetriggerAutomationsRequest = Components.Schemas.RetriggerAutomationsRequest;
 export type RetriggerAutomationsResult = Components.Schemas.RetriggerAutomationsResult;
 export type ServerError = Components.Schemas.ServerError;
@@ -2255,5 +2539,6 @@ export type SetupTariffChangeCampaignRequest = Components.Schemas.SetupTariffCha
 export type SetupTariffChangeCampaignResponse = Components.Schemas.SetupTariffChangeCampaignResponse;
 export type Target = Components.Schemas.Target;
 export type TargetQueryResult = Components.Schemas.TargetQueryResult;
+export type UpdateEntityUiStatusRequest = Components.Schemas.UpdateEntityUiStatusRequest;
 export type UpdatePortalStatusRequest = Components.Schemas.UpdatePortalStatusRequest;
 export type UpdateRecipientPayload = Components.Schemas.UpdateRecipientPayload;

--- a/clients/targeting-client/src/openapi.json
+++ b/clients/targeting-client/src/openapi.json
@@ -243,6 +243,42 @@
         }
       }
     },
+    "/v1/campaign:discover": {
+      "post": {
+        "operationId": "discoverCampaigns",
+        "summary": "Discover Entity-UI Next Best Actions for an entity",
+        "description": "Given an entity, returns the Next Best Actions it should see on the Entity-UI channel.\n\nEnumerates the organization's **active** campaigns that carry a valid Entity-UI Next Best\nAction, live-matches each against the entity using the existing match engine, and returns\nthe matching NBAs priority-sorted (one per campaign).\n\nThis is a pure read: it writes nothing. An entity that matches no campaigns returns an\nempty list, not an error.\n",
+        "tags": [
+          "Campaign"
+        ],
+        "security": [
+          {
+            "EpilotAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DiscoverCampaignsParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DiscoverCampaignsResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/ClientErrorResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerErrorResponse"
+          }
+        }
+      }
+    },
     "/v1/target:match": {
       "post": {
         "operationId": "matchTargets",
@@ -427,6 +463,56 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/UpdatePortalStatusRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RecipientResponse"
+          },
+          "400": {
+            "$ref": "#/components/responses/ClientErrorResponse"
+          },
+          "404": {
+            "$ref": "#/components/responses/ClientErrorResponse"
+          },
+          "409": {
+            "$ref": "#/components/responses/ClientErrorResponse"
+          },
+          "500": {
+            "$ref": "#/components/responses/ServerErrorResponse"
+          }
+        }
+      }
+    },
+    "/v1/campaign/{campaign_id}/recipient/{recipient_id}/entity_ui:status": {
+      "patch": {
+        "operationId": "updateRecipientEntityUiStatus",
+        "summary": "Update Entity-UI (Next Best Action) status for a campaign recipient",
+        "description": "Records a Next Best Action interaction for a recipient on the Entity-UI channel.\n\nUnlike the portal channel, an NBA recipient is created lazily: the first `seen` creates\nthe recipient record (and requires `entity_schema`). `seen` is idempotent — re-viewing an\nNBA that is already seen/clicked/dismissed is a no-op success and never regresses the status.\n\nStatus transition rules:\n- `seen`: lazily creates the recipient; a no-op success if a status already exists\n- From `seen`: can change to `clicked` or `dismissed`\n- From `clicked`: can change to `dismissed`\n- From `dismissed`: cannot be changed (final state)\n\n`dismissed` and `clicked` require an existing recipient (404 otherwise, since an NBA is\nborn at `seen`) and reject invalid transitions (409).\n\nThe entity_ui_status_updated_at timestamp is automatically set when the status changes.\n",
+        "tags": [
+          "Campaign Recipient"
+        ],
+        "security": [
+          {
+            "EpilotAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/CampaignIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/RecipientIdPathParam"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateEntityUiStatusRequest"
               }
             }
           }
@@ -918,6 +1004,122 @@
         ],
         "additionalProperties": false
       },
+      "NextBestAction": {
+        "type": "object",
+        "description": "A Next Best Action configured on a campaign's Entity-UI channel.\nThis is the canonical NBA contract shared by discovery (this API), authoring, and rendering.\nNBA content is single-language in v1; text fields may contain `{{placeholders}}` resolved at render time.\n",
+        "properties": {
+          "category": {
+            "type": "string",
+            "description": "Light category label shown above the title. Free-form text."
+          },
+          "icon": {
+            "type": "object",
+            "description": "Curated icon for the NBA.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Icon name from \"@epilot360/icons\"."
+              },
+              "color": {
+                "type": "string",
+                "description": "Optional icon color."
+              }
+            },
+            "required": [
+              "name"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "description": "Bold action title. Required. Supports `{{placeholders}}`."
+          },
+          "body": {
+            "type": "string",
+            "description": "Optional description. Supports `{{placeholders}}` (incl. relative dates)."
+          },
+          "priority": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ],
+            "default": "medium",
+            "description": "Display priority. NBAs are shown highest-priority first."
+          },
+          "is_dismissable": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether the agent can dismiss the NBA."
+          },
+          "cta": {
+            "type": "object",
+            "description": "The NBA's single call-to-action.",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "journey",
+                  "workflow",
+                  "url"
+                ]
+              },
+              "target": {
+                "type": "string",
+                "description": "Journey id, workflow definition id, or URL, depending on `type`."
+              },
+              "label": {
+                "type": "string",
+                "description": "Optional CTA button label."
+              },
+              "context_params": {
+                "type": "array",
+                "description": "Journey context parameters (journey CTA only). Maps the journey's declared\ncontext parameters so the journey knows which entity it is about. Discovery\nreturns them verbatim; they are passed to the journey when it launches.\n",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "value"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "type",
+              "target"
+            ]
+          }
+        },
+        "required": [
+          "title",
+          "cta"
+        ]
+      },
+      "DiscoverCampaignsParams": {
+        "type": "object",
+        "properties": {
+          "entity_id": {
+            "$ref": "#/components/schemas/BaseUUID"
+          },
+          "entity_schema": {
+            "type": "string",
+            "description": "The schema slug of the entity (e.g. \"contact\" or \"account\")."
+          }
+        },
+        "required": [
+          "entity_id",
+          "entity_schema"
+        ],
+        "additionalProperties": false
+      },
       "MatchTargetParams": {
         "type": "object",
         "properties": {
@@ -1022,6 +1224,22 @@
           "clicked"
         ]
       },
+      "EntityUiStatus": {
+        "type": "string",
+        "description": "Lifecycle status of a Next Best Action on the Entity-UI channel. Unlike the portal\nchannel there is no `sent` state: an NBA recipient is born at `seen`, the moment the\naction is first rendered to an agent.\n",
+        "enum": [
+          "seen",
+          "dismissed",
+          "clicked"
+        ]
+      },
+      "Resolution": {
+        "type": "string",
+        "description": "Cross-channel resolution of a campaign for a recipient. Unlike the per-channel `*_status`\nfields (where `dismissed` is channel-local), a resolution suppresses the campaign on EVERY\nchannel — the 360 Entity-UI card and the portal teaser alike. Server-managed and read-only:\nnever sent by a client. Absence means unresolved.\n",
+        "enum": [
+          "accepted"
+        ]
+      },
       "Recipient": {
         "type": "object",
         "properties": {
@@ -1050,6 +1268,16 @@
           "portal_state": {
             "type": "object",
             "additionalProperties": true
+          },
+          "entity_ui_status": {
+            "$ref": "#/components/schemas/EntityUiStatus"
+          },
+          "entity_ui_status_updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolution": {
+            "$ref": "#/components/schemas/Resolution"
           },
           "updated_at": {
             "type": "string",
@@ -1215,6 +1443,22 @@
         "required": [
           "status"
         ]
+      },
+      "UpdateEntityUiStatusRequest": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/EntityUiStatus"
+          },
+          "entity_schema": {
+            "type": "string",
+            "description": "Schema slug of the recipient entity (e.g. \"contact\"). Required when recording the\nfirst `seen`, which lazily creates the recipient record; ignored on later transitions.\n"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "additionalProperties": false
       },
       "SetupCampaignRequest": {
         "description": "Discriminated by `type`. Each campaign variant has its own request shape;\nnew variants are added by introducing a new schema and extending the `oneOf` list.\n",
@@ -1557,6 +1801,53 @@
                   }
                 }
               }
+            }
+          }
+        }
+      },
+      "DiscoverCampaignsResponse": {
+        "description": "The Next Best Actions the entity should see on the Entity-UI channel, priority-sorted.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "hits": {
+                  "type": "number",
+                  "description": "Number of matching NBAs."
+                },
+                "results": {
+                  "type": "array",
+                  "description": "Matching NBAs, sorted by priority (desc); one entry per campaign.",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "campaign_id": {
+                        "$ref": "#/components/schemas/BaseUUID"
+                      },
+                      "nba": {
+                        "$ref": "#/components/schemas/NextBestAction"
+                      },
+                      "status": {
+                        "allOf": [
+                          {
+                            "$ref": "#/components/schemas/EntityUiStatus"
+                          }
+                        ],
+                        "description": "The recipient's current Entity-UI status for this campaign, present only\nwhen a recipient record already exists (i.e. the entity has previously seen\nor clicked this NBA). Absent when the entity has not yet interacted with it.\nDismissed NBAs are filtered out server-side, so this is only ever `seen` or\n`clicked`. Lets the client skip a redundant `seen` call for NBAs already seen.\n"
+                      }
+                    },
+                    "required": [
+                      "campaign_id",
+                      "nba"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "hits",
+                "results"
+              ]
             }
           }
         }


### PR DESCRIPTION
## Summary

Regenerates `@epilot/targeting-client` from the current **prod** Targeting API spec (`https://docs.api.epilot.io/targeting.yaml`), adding the two Entity-UI Next Best Action operations the widgets MFE needs to migrate off hand-rolled `fetch`:

- **`discoverCampaigns`** — `POST /v1/campaign:discover`
- **`updateRecipientEntityUiStatus`** — `PATCH /v1/campaign/{campaign_id}/recipient/{recipient_id}/entity_ui:status`

Both endpoints are already live in prod (the spec at `docs.api.epilot.io/targeting.yaml` advertises them, and the NBA widget already calls them via raw `fetch`).

Changed files are the standard client-regen artifacts only (`src/openapi.json`, `src/openapi-runtime.json`, `src/openapi.d.ts`) plus a patch version bump — per `CONTRIBUTING.md` "Updating clients". The `@epilot/sdk` package itself is **not** committed here: the CI auto-release regenerates and publishes `@epilot/sdk` when a `clients/*/openapi.json` change lands on `main`.

## Context

- Blocker for **SIG-1338** (adopt `@epilot/sdk` in the widgets MFE).
- **Supersedes SIG-1276** — the stale `ellebrink/feat-nba-discovery-endpoint` branch is no longer needed and will be deleted.

## Test plan

- [x] `npm run openapi` (pulled prod spec — both ops present)
- [x] `npm run typegen && npm run build` succeed
- [x] Local `pnpm generate-sdk` confirms `@epilot/sdk/targeting` exposes `discoverCampaigns` + `updateRecipientEntityUiStatus`
- [ ] CI green → `@epilot/sdk` auto-release publishes new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)