### PR TITLE
chore(message-client): add inbox_id to searchIds (1.30.0)

### DIFF
--- a/clients/message-client/CHANGELOG.md
+++ b/clients/message-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 1.30.0
+
+### Minor Changes
+
+- "Add inbox_id to searchIds"
+
 ## 1.28.0
 
 - Added `unlink_mapped_entities` query param to `unassignThread` to also remove unassigned entities from `mapped_entities` on related source entities

--- a/clients/message-client/package.json
+++ b/clients/message-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/message-client",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "API Client for epilot Message API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/message-client/src/openapi.d.ts
+++ b/clients/message-client/src/openapi.d.ts
@@ -614,6 +614,7 @@ declare namespace Components {
          */
         export type ReadingScope = "organization" | "user";
         export interface SearchIDParams {
+            inbox_id?: string | string[];
             /**
              * Lucene query syntax supported with ElasticSearch
              * example:
@@ -2851,6 +2852,7 @@ declare namespace Paths {
     }
 }
 
+
 export interface OperationMethods {
   /**
    * updateMessage - updateMessage
@@ -4096,6 +4098,7 @@ export interface PathsDictionary {
 }
 
 export type Client = OpenAPIClient<OperationMethods, PathsDictionary>
+
 
 export type Address = Components.Schemas.Address;
 export type AssigneeWorkload = Components.Schemas.AssigneeWorkload;

--- a/clients/message-client/src/openapi.json
+++ b/clients/message-client/src/openapi.json
@@ -2745,6 +2745,26 @@
       "SearchIDParams": {
         "type": "object",
         "properties": {
+          "inbox_id": {
+            "oneOf": [
+              {
+                "type": "string",
+                "description": "Inbox ID",
+                "example": "3f34ce73-089c-4d45-a5ee-c161234e41c3"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Inbox IDs",
+                "example": [
+                  "3f34ce73-089c-4d45-a5ee-c161234e41c3",
+                  "3f34ce73-089c-4d45-a5ee-c161234e41c4"
+                ]
+              }
+            ]
+          },
           "q": {
             "description": "Lucene query syntax supported with ElasticSearch",
             "type": "string",


### PR DESCRIPTION
## Summary

Regenerate `@epilot/message-client` from the latest Message API spec to pick up
the new `inbox_id` parameter on the `searchIds` operation
(`POST /v1/message/threads:searchIds`).

Bumps `@epilot/message-client` `1.29.0 → 1.30.0` (minor).

## Why

The central-inbox "Select all" action calls `searchIds` to get the full set of
matching thread ids. That endpoint was only scoped by the Lucene query, not by
inbox — so "Select all" selected threads across every accessible inbox instead
of just the current one (STABLE360-12157 / SIG-814).

The Message API backend now accepts `inbox_id` on `searchIds` and scopes the
result set accordingly. This PR brings that field into the generated client
types so consumers can pass it without a local type cast.

## Changes

- `src/openapi.json` + `src/openapi.d.ts`: regenerated from prod spec — adds
  `inbox_id?: string | string[]` to `SearchIDParams`
- `package.json`: `1.29.0 → 1.30.0`
- `CHANGELOG.md`: 1.30.0 entry

## Related

- Backend: svc-centralized-message-api MR !384 (adds `inbox_id` to `searchIds`)
- Consumer: epilot360-messaging MR !1169 (passes `inbox_id`, will drop its local cast once this is published)

## Test plan

- [x] `npm run openapi && npm run typegen && npm run build` regenerates cleanly
- [x] `SearchIDParams` now includes `inbox_id`
- [ ] Publish `@epilot/message-client@1.30.0`, bump + remove cast in epilot360-messaging