### PR TITLE
feat(user-client): add passkeys_registered to LoginParameters

### DIFF
--- a/.changeset/user-client-passkeys-registered.md
+++ b/.changeset/user-client-passkeys-registered.md
@@ -1,0 +1,7 @@
+---
+"@epilot/user-client": minor
+---
+
+Add `passkeys_registered` to `LoginParameters`
+
+`getUserLoginParameters` now reports whether the user has at least one passkey registered, so the login UI can offer passkey authentication as an alternative to typing an MFA code.

--- a/clients/user-client/src/openapi.d.ts
+++ b/clients/user-client/src/openapi.d.ts
@@ -441,6 +441,14 @@ declare namespace Components {
              * Whether passkey login is enabled for this organization
              */
             passkey_enabled?: boolean;
+            /**
+             * Whether the user has at least one passkey registered. Lets the login
+             * UI offer passkey authentication as an alternative to an MFA code.
+             * Discloses nothing that :beginPasskeyAuthentication doesn't already
+             * reveal for a known email address.
+             *
+             */
+            passkeys_registered?: boolean;
         }
         /**
          * A customized workplace navigation configuration. The ID is a content-hash, so identical configurations will have the same ID.

--- a/clients/user-client/src/openapi.json
+++ b/clients/user-client/src/openapi.json
@@ -2443,6 +2443,10 @@
           "passkey_enabled": {
             "type": "boolean",
             "description": "Whether passkey login is enabled for this organization"
+          },
+          "passkeys_registered": {
+            "type": "boolean",
+            "description": "Whether the user has at least one passkey registered. Lets the login\nUI offer passkey authentication as an alternative to an MFA code.\nDiscloses nothing that :beginPasskeyAuthentication doesn't already\nreveal for a known email address.\n"
           }
         }
       },


### PR DESCRIPTION
## Summary

Regenerates `@epilot/user-client` to pick up `passkeys_registered` on `LoginParameters`, which shipped in user-api's `openapi.yml`.

The login MFE uses this to decide whether to offer **Sign in with passkey** at the second-factor step of a password login. It currently carries a local `LoginParametersWithPasskeys` type as a stopgap; once this client is published that shim can go.

## Changes

- `clients/user-client/src/openapi.json` / `openapi.d.ts` — regenerated
- `.changeset/user-client-passkeys-registered.md` — patch bump

Generated output only; no hand-written source changes.

## Test plan

- [x] Rebased onto current `main` (the branch was 34 commits behind, so the earlier diff would have reverted unrelated work)
- [x] Diff is limited to the 3 files above
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mpk1XSwY1XKpHKubaNHbY3)_