### PR TITLE
feat(deduplication-client): dismissDuplicates operation + response fix

### DIFF
--- a/clients/deduplication-client/package.json
+++ b/clients/deduplication-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/deduplication-client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JavaScript client library for Epilot's Deduplication API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/deduplication-client/src/openapi-runtime.json
+++ b/clients/deduplication-client/src/openapi-runtime.json
@@ -51,6 +51,17 @@
         "responses": {}
       }
     },
+    "/v1/duplicates/dismiss": {
+      "post": {
+        "operationId": "dismissDuplicates",
+        "requestBody": {
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      }
+    },
     "/v1/uniqueness-criteria": {
       "get": {
         "operationId": "listUniquenessCriteria",

--- a/clients/deduplication-client/src/openapi.d.ts
+++ b/clients/deduplication-client/src/openapi.d.ts
@@ -50,7 +50,12 @@ declare namespace Components {
                 ];
             }[]
         ];
-        export type DeduplicateRequestResponse = /* Base Entity schema */ Entity[];
+        export interface DeduplicateRequestResponse {
+            /**
+             * The merged survivor entity of each processed set
+             */
+            deduplicatedEntities: /* Base Entity schema */ Entity[];
+        }
         /**
          * Represents an async deduplication job
          */
@@ -105,6 +110,120 @@ declare namespace Components {
                 string,
                 ...string[]
             ];
+        }
+        export interface DismissDuplicatesRequestBody {
+            schema: string;
+            /**
+             * Entities whose duplicate flags (_matching_entities) are cleared — the records are confirmed as NOT duplicates and stay separate
+             */
+            entityIds: [
+                string,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?,
+                string?
+            ];
+        }
+        export interface DismissDuplicatesResponse {
+            /**
+             * Entity ids whose duplicate flags were cleared
+             */
+            dismissed: string[];
         }
         /**
          * Base Entity schema
@@ -279,6 +398,12 @@ declare namespace Paths {
             export type $200 = Components.Schemas.DetectDuplicatesResponse;
         }
     }
+    namespace DismissDuplicates {
+        export type RequestBody = Components.Schemas.DismissDuplicatesRequestBody;
+        namespace Responses {
+            export type $200 = Components.Schemas.DismissDuplicatesResponse;
+        }
+    }
     namespace GetDeduplicationJob {
         namespace Parameters {
             export type JobId = string;
@@ -374,6 +499,16 @@ export interface OperationMethods {
     data?: Paths.DetectDuplicates.RequestBody,
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.DetectDuplicates.Responses.$200>
+  /**
+   * dismissDuplicates - dismissDuplicates
+   * 
+   * Confirms entities as NOT duplicates: clears the internal duplicate-detection flags (_matching_entities) on each given entity, so they stop appearing as open duplicate sets. The records themselves are not modified otherwise.
+   */
+  'dismissDuplicates'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.DismissDuplicates.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.DismissDuplicates.Responses.$200>
   /**
    * listUniquenessCriteria - listUniquenessCriteria
    * 
@@ -475,6 +610,18 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.DetectDuplicates.Responses.$200>
   }
+  ['/v1/duplicates/dismiss']: {
+    /**
+     * dismissDuplicates - dismissDuplicates
+     * 
+     * Confirms entities as NOT duplicates: clears the internal duplicate-detection flags (_matching_entities) on each given entity, so they stop appearing as open duplicate sets. The records themselves are not modified otherwise.
+     */
+    'post'(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.DismissDuplicates.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.DismissDuplicates.Responses.$200>
+  }
   ['/v1/uniqueness-criteria']: {
     /**
      * listUniquenessCriteria - listUniquenessCriteria
@@ -541,6 +688,8 @@ export type DeduplicationJob = Components.Schemas.DeduplicationJob;
 export type DetectDuplicatesRequestBody = Components.Schemas.DetectDuplicatesRequestBody;
 export type DetectDuplicatesResponse = Components.Schemas.DetectDuplicatesResponse;
 export type DetectedDuplicateMatch = Components.Schemas.DetectedDuplicateMatch;
+export type DismissDuplicatesRequestBody = Components.Schemas.DismissDuplicatesRequestBody;
+export type DismissDuplicatesResponse = Components.Schemas.DismissDuplicatesResponse;
 export type Entity = Components.Schemas.Entity;
 export type JobStatus = Components.Schemas.JobStatus;
 export type MatchAttribute = Components.Schemas.MatchAttribute;

--- a/clients/deduplication-client/src/openapi.json
+++ b/clients/deduplication-client/src/openapi.json
@@ -132,6 +132,35 @@
         }
       }
     },
+    "/v1/duplicates/dismiss": {
+      "post": {
+        "operationId": "dismissDuplicates",
+        "summary": "dismissDuplicates",
+        "description": "Confirms entities as NOT duplicates: clears the internal duplicate-detection flags (_matching_entities) on each given entity, so they stop appearing as open duplicate sets. The records themselves are not modified otherwise.",
+        "tags": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DismissDuplicatesRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Flags cleared",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DismissDuplicatesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/uniqueness-criteria": {
       "get": {
         "operationId": "listUniquenessCriteria",
@@ -329,10 +358,19 @@
         "minItems": 1
       },
       "DeduplicateRequestResponse": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Entity"
-        }
+        "type": "object",
+        "properties": {
+          "deduplicatedEntities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Entity"
+            },
+            "description": "The merged survivor entity of each processed set"
+          }
+        },
+        "required": [
+          "deduplicatedEntities"
+        ]
       },
       "Entity": {
         "type": "object",
@@ -555,6 +593,44 @@
           "entity",
           "confidence",
           "matched_attributes"
+        ]
+      },
+      "DismissDuplicatesRequestBody": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "type": "string",
+            "minLength": 1
+          },
+          "entityIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "maxItems": 100,
+            "description": "Entities whose duplicate flags (_matching_entities) are cleared — the records are confirmed as NOT duplicates and stay separate"
+          }
+        },
+        "required": [
+          "schema",
+          "entityIds"
+        ]
+      },
+      "DismissDuplicatesResponse": {
+        "type": "object",
+        "properties": {
+          "dismissed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Entity ids whose duplicate flags were cleared"
+          }
+        },
+        "required": [
+          "dismissed"
         ]
       },
       "UniquenessCriteriaListResponse": {


### PR DESCRIPTION
Refreshed from deduplication-api after the manage-duplicates rework merged: adds POST /v1/duplicates/dismiss (clears _matching_entities duplicate flags — the review page's "Keep all entries" action) and aligns the deduplicate response type with the implementation ({ deduplicatedEntities } wrapper). Bumps to 0.4.0.