### PR TITLE
chore(file-client): add file summary feedback operations

### DIFF
--- a/clients/file-client/package.json
+++ b/clients/file-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/file-client",
-  "version": "1.28.1",
+  "version": "1.28.2",
   "description": "Client library for the epilot File API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/file-client/src/openapi-runtime.json
+++ b/clients/file-client/src/openapi-runtime.json
@@ -236,6 +236,36 @@
         "responses": {}
       }
     },
+    "/v1/files/{id}/summary/feedback": {
+      "get": {
+        "operationId": "getFileSummaryFeedback",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {}
+      },
+      "put": {
+        "operationId": "putFileSummaryFeedback",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      }
+    },
     "/v1/files/{id}/summary-jobs": {
       "post": {
         "operationId": "createFileSummaryJob",

--- a/clients/file-client/src/openapi.d.ts
+++ b/clients/file-client/src/openapi.d.ts
@@ -2489,6 +2489,10 @@ declare namespace Components {
              * Short English paragraph summary for file preview surfaces.
              */
             short_summary_en?: string;
+            /**
+             * AI execution that produced the current summary. Used to correlate user feedback.
+             */
+            file_summary_execution_id?: string; // uuid
         }
         export interface FileCollectionAttributes {
             /**
@@ -2717,6 +2721,10 @@ declare namespace Components {
              */
             short_summary_en?: string;
             /**
+             * AI execution that produced the current summary. Used to correlate user feedback.
+             */
+            file_summary_execution_id?: string; // uuid
+            /**
              * Source URL for the file. Included if the entity was created from source_url, or when ?source_url=true
              * example:
              * https://productengineer-content.s3.eu-west-1.amazonaws.com/product-engineer-checklist.pdf
@@ -2800,6 +2808,10 @@ declare namespace Components {
              */
             job_id?: string; // uuid
             /**
+             * Whether the current summary can receive user feedback.
+             */
+            feedback_available?: boolean;
+            /**
              * Compact German summary for hover and list preview surfaces.
              */
             preview_summary_de?: string | null;
@@ -2815,6 +2827,20 @@ declare namespace Components {
              * Short English paragraph summary for file preview surfaces.
              */
             short_summary_en?: string | null;
+        }
+        export interface FileSummaryFeedback {
+            rating: "up" | "down";
+            comment?: string;
+            user_id: string;
+            submitted_at: string; // date-time
+        }
+        export interface FileSummaryFeedbackResponse {
+            feedback: {
+                rating: "up" | "down";
+                comment?: string;
+                user_id: string;
+                submitted_at: string; // date-time
+            } | null;
         }
         export interface FileSummaryJob {
             /**
@@ -2902,6 +2928,10 @@ declare namespace Components {
              * The most recent timestamp when the file was accessed
              */
             last_accessed_at?: string;
+        }
+        export interface PutFileSummaryFeedbackRequest {
+            rating: "up" | "down";
+            comment?: string;
         }
         export type S3Ref = S3Reference;
         export interface S3Reference {
@@ -3022,6 +3052,10 @@ declare namespace Components {
              * Short English paragraph summary for file preview surfaces.
              */
             short_summary_en?: string;
+            /**
+             * AI execution that produced the current summary. Used to correlate user feedback.
+             */
+            file_summary_execution_id?: string; // uuid
         }
         export interface SaveFileFromSourceURLPayload {
             [name: string]: any;
@@ -3129,6 +3163,10 @@ declare namespace Components {
              * Short English paragraph summary for file preview surfaces.
              */
             short_summary_en?: string;
+            /**
+             * AI execution that produced the current summary. Used to correlate user feedback.
+             */
+            file_summary_execution_id?: string; // uuid
             source_url?: /**
              * Custom external download url used for the file
              * example:
@@ -3244,6 +3282,10 @@ declare namespace Components {
              * Short English paragraph summary for file preview surfaces.
              */
             short_summary_en?: string;
+            /**
+             * AI execution that produced the current summary. Used to correlate user feedback.
+             */
+            file_summary_execution_id?: string; // uuid
             s3ref?: S3Ref;
         }
         export interface UploadFilePayload {
@@ -4140,6 +4182,66 @@ declare namespace Paths {
             Components.Responses.InternalServerError;
         }
     }
+    namespace GetFileSummaryFeedback {
+        namespace Parameters {
+            export type Id = /**
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            Components.Schemas.FileEntityId;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        namespace Responses {
+            export type $200 = Components.Schemas.FileSummaryFeedbackResponse;
+            export type $400 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 400,
+             *   "error": "Bad Request: filename is required"
+             * }
+             */
+            Components.Responses.BadRequestError;
+            export type $401 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 401,
+             *   "error": "Unauthorized: Invalid or expired token"
+             * }
+             */
+            Components.Responses.UnauthorizedError;
+            export type $403 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 403,
+             *   "error": "Forbidden: You do not have permission to access this file"
+             * }
+             */
+            Components.Responses.ForbiddenError;
+            export type $404 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 404,
+             *   "error": "Not Found: File entity not found"
+             * }
+             */
+            Components.Responses.NotFoundError;
+            export type $500 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 500,
+             *   "error": "Internal Server Error"
+             * }
+             */
+            Components.Responses.InternalServerError;
+        }
+    }
     namespace GetFileSummaryJob {
         namespace Parameters {
             export type Id = /**
@@ -4625,6 +4727,76 @@ declare namespace Paths {
              * }
              */
             Components.Responses.NotFoundError;
+            export type $500 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 500,
+             *   "error": "Internal Server Error"
+             * }
+             */
+            Components.Responses.InternalServerError;
+        }
+    }
+    namespace PutFileSummaryFeedback {
+        namespace Parameters {
+            export type Id = /**
+             * example:
+             * ef7d985c-2385-44f4-9c71-ae06a52264f8
+             */
+            Components.Schemas.FileEntityId;
+        }
+        export interface PathParameters {
+            id: Parameters.Id;
+        }
+        export type RequestBody = Components.Schemas.PutFileSummaryFeedbackRequest;
+        namespace Responses {
+            export type $200 = Components.Schemas.FileSummaryFeedbackResponse;
+            export type $400 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 400,
+             *   "error": "Bad Request: filename is required"
+             * }
+             */
+            Components.Responses.BadRequestError;
+            export type $401 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 401,
+             *   "error": "Unauthorized: Invalid or expired token"
+             * }
+             */
+            Components.Responses.UnauthorizedError;
+            export type $403 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 403,
+             *   "error": "Forbidden: You do not have permission to access this file"
+             * }
+             */
+            Components.Responses.ForbiddenError;
+            export type $404 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 404,
+             *   "error": "Not Found: File entity not found"
+             * }
+             */
+            Components.Responses.NotFoundError;
+            export type $409 = /**
+             * A generic error returned by the API
+             * example:
+             * {
+             *   "status": 409,
+             *   "error": "Extracted file content is still being prepared"
+             * }
+             */
+            Components.Responses.ConflictError;
             export type $500 = /**
              * A generic error returned by the API
              * example:
@@ -5201,6 +5373,26 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.GetFileSummary.Responses.$200>
   /**
+   * getFileSummaryFeedback - Get file summary feedback
+   *
+   * Get the authenticated user's feedback for the current generated file summary.
+   */
+  'getFileSummaryFeedback'(
+    parameters?: Parameters<Paths.GetFileSummaryFeedback.PathParameters> | null,
+    data?: any,
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.GetFileSummaryFeedback.Responses.$200>
+  /**
+   * putFileSummaryFeedback - Submit file summary feedback
+   *
+   * Upsert thumbs up/down feedback for the current generated file summary.
+   */
+  'putFileSummaryFeedback'(
+    parameters?: Parameters<Paths.PutFileSummaryFeedback.PathParameters> | null,
+    data?: Paths.PutFileSummaryFeedback.RequestBody,
+    config?: AxiosRequestConfig
+  ): OperationResponse<Paths.PutFileSummaryFeedback.Responses.$200>
+  /**
    * createFileSummaryJob - createFileSummaryJob
    * 
    * Create or return the current AI summary job for a file entity.
@@ -5722,6 +5914,28 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.GetFileSummary.Responses.$200>
   }
+  ['/v1/files/{id}/summary/feedback']: {
+    /**
+     * getFileSummaryFeedback - Get file summary feedback
+     *
+     * Get the authenticated user's feedback for the current generated file summary.
+     */
+    'get'(
+      parameters?: Parameters<Paths.GetFileSummaryFeedback.PathParameters> | null,
+      data?: any,
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.GetFileSummaryFeedback.Responses.$200>
+    /**
+     * putFileSummaryFeedback - Submit file summary feedback
+     *
+     * Upsert thumbs up/down feedback for the current generated file summary.
+     */
+    'put'(
+      parameters?: Parameters<Paths.PutFileSummaryFeedback.PathParameters> | null,
+      data?: Paths.PutFileSummaryFeedback.RequestBody,
+      config?: AxiosRequestConfig
+    ): OperationResponse<Paths.PutFileSummaryFeedback.Responses.$200>
+  }
   ['/v1/files/{id}/summary-jobs']: {
     /**
      * createFileSummaryJob - createFileSummaryJob
@@ -6092,6 +6306,8 @@ export type FileEntityId = Components.Schemas.FileEntityId;
 export type FileItem = Components.Schemas.FileItem;
 export type FileRelationItem = Components.Schemas.FileRelationItem;
 export type FileSummary = Components.Schemas.FileSummary;
+export type FileSummaryFeedback = Components.Schemas.FileSummaryFeedback;
+export type FileSummaryFeedbackResponse = Components.Schemas.FileSummaryFeedbackResponse;
 export type FileSummaryJob = Components.Schemas.FileSummaryJob;
 export type FileSummaryJobStatus = Components.Schemas.FileSummaryJobStatus;
 export type FileText = Components.Schemas.FileText;
@@ -6102,6 +6318,7 @@ export type FileTextUnsupported = Components.Schemas.FileTextUnsupported;
 export type FileType = Components.Schemas.FileType;
 export type FileUpload = Components.Schemas.FileUpload;
 export type PublicLink = Components.Schemas.PublicLink;
+export type PutFileSummaryFeedbackRequest = Components.Schemas.PutFileSummaryFeedbackRequest;
 export type S3Ref = Components.Schemas.S3Ref;
 export type S3Reference = Components.Schemas.S3Reference;
 export type SaveCustomFilePayload = Components.Schemas.SaveCustomFilePayload;

--- a/clients/file-client/src/openapi.json
+++ b/clients/file-client/src/openapi.json
@@ -940,6 +940,113 @@
         }
       }
     },
+    "/v1/files/{id}/summary/feedback": {
+      "get": {
+        "operationId": "getFileSummaryFeedback",
+        "summary": "Get file summary feedback",
+        "description": "Get the authenticated user's feedback for the current generated file summary.",
+        "tags": [
+          "File"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The UUID of the file entity",
+            "schema": {
+              "$ref": "#/components/schemas/FileEntityId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current feedback state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSummaryFeedbackResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      },
+      "put": {
+        "operationId": "putFileSummaryFeedback",
+        "summary": "Submit file summary feedback",
+        "description": "Upsert thumbs up/down feedback for the current generated file summary.",
+        "tags": [
+          "File"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The UUID of the file entity",
+            "schema": {
+              "$ref": "#/components/schemas/FileEntityId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PutFileSummaryFeedbackRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Feedback recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSummaryFeedbackResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequestError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "409": {
+            "$ref": "#/components/responses/ConflictError"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/v1/files/{id}/summary-jobs": {
       "post": {
         "operationId": "createFileSummaryJob",
@@ -2512,6 +2619,12 @@
             "type": "string",
             "description": "Short English paragraph summary for file preview surfaces.",
             "readOnly": true
+          },
+          "file_summary_execution_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "AI execution that produced the current summary. Used to correlate user feedback.",
+            "readOnly": true
           }
         }
       },
@@ -2596,6 +2709,10 @@
             "format": "uuid",
             "description": "Current summary job ID when available."
           },
+          "feedback_available": {
+            "type": "boolean",
+            "description": "Whether the current summary can receive user feedback."
+          },
           "preview_summary_de": {
             "type": "string",
             "nullable": true,
@@ -2615,6 +2732,67 @@
             "type": "string",
             "nullable": true,
             "description": "Short English paragraph summary for file preview surfaces."
+          }
+        }
+      },
+      "FileSummaryFeedback": {
+        "type": "object",
+        "required": [
+          "rating",
+          "user_id",
+          "submitted_at"
+        ],
+        "properties": {
+          "rating": {
+            "type": "string",
+            "enum": [
+              "up",
+              "down"
+            ]
+          },
+          "comment": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
+          },
+          "submitted_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "FileSummaryFeedbackResponse": {
+        "type": "object",
+        "required": [
+          "feedback"
+        ],
+        "properties": {
+          "feedback": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/FileSummaryFeedback"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "PutFileSummaryFeedbackRequest": {
+        "type": "object",
+        "required": [
+          "rating"
+        ],
+        "properties": {
+          "rating": {
+            "type": "string",
+            "enum": [
+              "up",
+              "down"
+            ]
+          },
+          "comment": {
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
## Summary

- add typed `getFileSummaryFeedback` and `putFileSummaryFeedback` operations to `@epilot/file-client`
- expose feedback correlation fields and feedback request/response schemas
- bump `@epilot/file-client` from `1.28.1` to `1.28.2`
- preserve the existing API contract; the generated change is additive apart from the package version bump

## Why

File summary consumers can use the typed File API feedback endpoints instead of raw requests once this package is published.

## Dependency

- File API MR [!279](https://gitlab.com/e-pilot/product/file-management/file-api/-/merge_requests/279) provides this contract and must be merged and deployed before consumers use the new endpoints.

## Validation

- `npm run build`
- `npm run lint`
- `npm test -- --run` — 3 tests passed
- `git diff --check`
