### PR TITLE
feat(calendar-client): update API definitions

### DIFF
--- a/clients/calendar-client/src/openapi.d.ts
+++ b/clients/calendar-client/src/openapi.d.ts
@@ -123,7 +123,7 @@ declare namespace Components {
              */
             is_default: boolean;
             /**
-             * True if the caller cannot modify events in this calendar
+             * True if the caller cannot create, update, or delete events in this calendar
              */
             read_only: boolean;
             owner_email?: string | null; // email
@@ -182,7 +182,14 @@ declare namespace Components {
              * Convenience flag, true when status is busy/oof/tentative
              */
             busy: boolean;
+            /**
+             * Whether the event was cancelled but still exists
+             */
             is_cancelled: boolean;
+            /**
+             * Whether the event is saved as a draft
+             */
+            is_draft: boolean;
             sensitivity: Sensitivity;
             importance: Importance;
             is_online_meeting: boolean;
@@ -200,6 +207,9 @@ declare namespace Components {
              * Null when sensitivity is private or confidential
              */
             attendees?: Attendee[] | null;
+            metadata?: {
+                [name: string]: any;
+            } | null;
             is_recurring: boolean;
             /**
              * ID of the recurring series this occurrence belongs to
@@ -234,6 +244,9 @@ declare namespace Components {
             location?: string | null;
             status: /* Free/busy state derived from provider `showAs` */ EventStatus;
             sensitivity: Sensitivity;
+            metadata?: {
+                [name: string]: any;
+            } | null;
             _title: string;
         }
         export interface CalendarEventPatchBody {
@@ -256,6 +269,10 @@ declare namespace Components {
             is_all_day?: boolean;
             location?: string | null;
             status?: /* Free/busy state derived from provider `showAs` */ EventStatus;
+            /**
+             * Whether the event was cancelled but still exists
+             */
+            is_cancelled?: boolean;
             sensitivity?: Sensitivity;
             _title?: string;
         }
@@ -1254,7 +1271,6 @@ declare namespace Paths {
         namespace Responses {
             export interface $204 {
             }
-            export type $403 = Components.Schemas.Error;
             export type $404 = Components.Schemas.Error;
         }
     }
@@ -1661,7 +1677,6 @@ declare namespace Paths {
         namespace Responses {
             export type $200 = Components.Schemas.Calendar;
             export type $400 = Components.Schemas.Error;
-            export type $403 = Components.Schemas.Error;
             export type $404 = Components.Schemas.Error;
         }
     }
@@ -1896,7 +1911,7 @@ export interface OperationMethods {
   /**
    * updateCalendar - updateCalendar
    * 
-   * Update fields on a calendar.
+   * Update local calendar details. Changes to synced calendars do not modify the provider calendar.
    */
   'updateCalendar'(
     parameters?: Parameters<Paths.UpdateCalendar.PathParameters> | null,
@@ -1906,7 +1921,7 @@ export interface OperationMethods {
   /**
    * deleteCalendar - deleteCalendar
    * 
-   * Delete a native epilot calendar and its events.
+   * Delete a native epilot calendar or disconnect a synced calendar, including its locally stored events.
    */
   'deleteCalendar'(
     parameters?: Parameters<Paths.DeleteCalendar.PathParameters> | null,
@@ -2223,7 +2238,7 @@ export interface PathsDictionary {
     /**
      * updateCalendar - updateCalendar
      * 
-     * Update fields on a calendar.
+     * Update local calendar details. Changes to synced calendars do not modify the provider calendar.
      */
     'patch'(
       parameters?: Parameters<Paths.UpdateCalendar.PathParameters> | null,
@@ -2233,7 +2248,7 @@ export interface PathsDictionary {
     /**
      * deleteCalendar - deleteCalendar
      * 
-     * Delete a native epilot calendar and its events.
+     * Delete a native epilot calendar or disconnect a synced calendar, including its locally stored events.
      */
     'delete'(
       parameters?: Parameters<Paths.DeleteCalendar.PathParameters> | null,

--- a/clients/calendar-client/src/openapi.json
+++ b/clients/calendar-client/src/openapi.json
@@ -1241,7 +1241,7 @@
       "patch": {
         "operationId": "updateCalendar",
         "summary": "updateCalendar",
-        "description": "Update fields on a calendar.",
+        "description": "Update local calendar details. Changes to synced calendars do not modify the provider calendar.",
         "tags": [
           "Calendars"
         ],
@@ -1286,16 +1286,6 @@
               }
             }
           },
-          "403": {
-            "description": "Calendar is read-only",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
           "404": {
             "description": "Resource not found",
             "content": {
@@ -1311,7 +1301,7 @@
       "delete": {
         "operationId": "deleteCalendar",
         "summary": "deleteCalendar",
-        "description": "Delete a native epilot calendar and its events.",
+        "description": "Delete a native epilot calendar or disconnect a synced calendar, including its locally stored events.",
         "tags": [
           "Calendars"
         ],
@@ -1327,17 +1317,7 @@
         ],
         "responses": {
           "204": {
-            "description": "Calendar deleted"
-          },
-          "403": {
-            "description": "Calendar is read-only",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
+            "description": "Calendar deleted or disconnected"
           },
           "404": {
             "description": "Resource not found",
@@ -2347,7 +2327,7 @@
           },
           "read_only": {
             "type": "boolean",
-            "description": "True if the caller cannot modify events in this calendar"
+            "description": "True if the caller cannot create, update, or delete events in this calendar"
           },
           "owner_email": {
             "type": "string",
@@ -2573,7 +2553,12 @@
             "description": "Convenience flag, true when status is busy/oof/tentative"
           },
           "is_cancelled": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "Whether the event was cancelled but still exists"
+          },
+          "is_draft": {
+            "type": "boolean",
+            "description": "Whether the event is saved as a draft"
           },
           "sensitivity": {
             "$ref": "#/components/schemas/Sensitivity"
@@ -2612,6 +2597,11 @@
             },
             "description": "Null when sensitivity is private or confidential"
           },
+          "metadata": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {}
+          },
           "is_recurring": {
             "type": "boolean"
           },
@@ -2645,6 +2635,7 @@
           "status",
           "busy",
           "is_cancelled",
+          "is_draft",
           "sensitivity",
           "importance",
           "is_online_meeting",
@@ -2813,6 +2804,11 @@
           "sensitivity": {
             "$ref": "#/components/schemas/Sensitivity"
           },
+          "metadata": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {}
+          },
           "_title": {
             "type": "string",
             "minLength": 1
@@ -2862,6 +2858,10 @@
           },
           "status": {
             "$ref": "#/components/schemas/EventStatus"
+          },
+          "is_cancelled": {
+            "type": "boolean",
+            "description": "Whether the event was cancelled but still exists"
           },
           "sensitivity": {
             "$ref": "#/components/schemas/Sensitivity"


### PR DESCRIPTION
## Summary

- refresh the Calendar API client definition from the production OpenAPI source
- add event draft, cancellation, and metadata fields to the generated types
- align calendar update and delete responses with synced-calendar behavior

## Verification

- `pnpm --filter @epilot/calendar-client openapi`
- `pnpm --filter @epilot/calendar-client typegen`
- `pnpm --filter @epilot/calendar-client build`