### PR TITLE
feat(message-client): add getUnreadCounts

### DIFF
--- a/.changeset/message-client-unread-counts.md
+++ b/.changeset/message-client-unread-counts.md
@@ -1,0 +1,9 @@
+---
+"@epilot/message-client": minor
+---
+
+Add `getUnreadCounts` for the consolidated unread-counts endpoint
+
+`POST /v1/message/unread:counts` returns unread counts for several named scopes in one request. A scope is a name plus the parameters the thread list already takes (`q`, `inbox_id`), and the server adds only the read-state condition — so a badge and the list beneath it are one predicate rather than two authored copies. The `organization` scope is the exception and takes no `q`, reusing the four canonical central-inbox queries so its numbers match `getUnread` exactly.
+
+Gated on the `message-unread-counts` flag: with it off the response is `{ "enabled": false, "counts": {} }`.

--- a/clients/message-client/src/openapi-runtime.json
+++ b/clients/message-client/src/openapi-runtime.json
@@ -162,6 +162,18 @@
         "responses": {}
       }
     },
+    "/v1/message/unread:counts": {
+      "post": {
+        "operationId": "getUnreadCounts",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {}
+          }
+        },
+        "responses": {}
+      }
+    },
     "/v2/message/messages/{id}/unread": {
       "post": {
         "operationId": "markUnreadMessageV2",

--- a/clients/message-client/src/openapi.d.ts
+++ b/clients/message-client/src/openapi.d.ts
@@ -342,6 +342,49 @@ declare namespace Components {
              */
             template_id?: string;
         }
+        export interface MessageAutoReplySentEvent {
+            type: "MESSAGE_AUTO_REPLY_SENT";
+            /**
+             * ID of the message that was sent as the automatic reply
+             */
+            reply_message_id?: string;
+            /**
+             * ID of the message the automatic reply responded to
+             */
+            parent_message_id?: string;
+        }
+        export interface MessageEntityLinkedEvent {
+            type: "MESSAGE_ENTITY_LINKED";
+            entities?: TimelineLinkedEntity[];
+            link_kind?: "manual" | "auto";
+        }
+        export interface MessageEntityUnlinkedEvent {
+            type: "MESSAGE_ENTITY_UNLINKED";
+            entities?: TimelineLinkedEntity[];
+            link_kind?: "manual" | "auto";
+        }
+        export interface MessageLabelAddedEvent {
+            type: "MESSAGE_LABEL_ADDED";
+            /**
+             * The label that was added (raw tag slug, e.g. `sentiments:angry`)
+             */
+            label: string;
+            /**
+             * Resolved taxonomy classification display name (e.g. `Verärgert`), when the label is a classification. Absent for free-form tags.
+             */
+            label_name?: string;
+        }
+        export interface MessageLabelRemovedEvent {
+            type: "MESSAGE_LABEL_REMOVED";
+            /**
+             * The label that was removed (raw tag slug, e.g. `sentiments:angry`)
+             */
+            label: string;
+            /**
+             * Resolved taxonomy classification display name (e.g. `Verärgert`), when the label is a classification. Absent for free-form tags.
+             */
+            label_name?: string;
+        }
         export interface MessageRequestParams {
             [name: string]: any;
             /**
@@ -724,6 +767,17 @@ declare namespace Components {
              */
             organization_id: string;
         }
+        export interface ThreadMovedToInboxEvent {
+            type: "THREAD_MOVED_TO_INBOX";
+            /**
+             * ID of the shared inbox the thread was moved to
+             */
+            target_inbox_id?: string;
+            /**
+             * Name of the shared inbox the thread was moved to
+             */
+            target_inbox_name?: string;
+        }
         export interface ThreadOpenEvent {
             type: "THREAD_OPEN";
             /**
@@ -739,19 +793,206 @@ declare namespace Components {
              */
             organization_id: string;
         }
+        export interface ThreadRestoredEvent {
+            type: "THREAD_RESTORED";
+        }
         export interface ThreadTimeline {
             events: TimelineEvent[];
         }
+        export interface ThreadTrashedEvent {
+            type: "THREAD_TRASHED";
+        }
+        export interface ThreadUserAssignedEvent {
+            type: "THREAD_USER_ASSIGNED";
+            /**
+             * User IDs assigned to the thread
+             */
+            added?: string[];
+            /**
+             * User IDs unassigned from the thread
+             */
+            removed?: string[];
+        }
+        export interface TimelineActor {
+            user_id?: string;
+            email?: string;
+        }
         export interface TimelineEvent {
+            /**
+             * Activity id (ActivityItem._id), for deep-linking to the item in the activity feed
+             */
+            id?: string;
             data: TimelineEventData;
             /**
              * Timestamp of the event
              * example:
-             * 2024-01-01T00:00:00.000Z
+             * 2024-01-01T00:00:00Z
              */
             timestamp: string;
+            /**
+             * For message-level events, the message the activity is anchored to
+             */
+            message_id?: string;
+            source?: "user" | "automation" | "system";
+            /**
+             * Whether the activity was performed automatically (automation/system)
+             */
+            automated?: boolean;
+            actor?: TimelineActor;
+            automation?: {
+                id?: string;
+                name?: string;
+            };
         }
-        export type TimelineEventData = ThreadDoneEvent | ThreadOpenEvent;
+        export type TimelineEventData = ThreadDoneEvent | ThreadOpenEvent | WorkflowStartedEvent | ThreadUserAssignedEvent | MessageLabelAddedEvent | MessageLabelRemovedEvent | MessageEntityLinkedEvent | MessageEntityUnlinkedEvent | MessageAutoReplySentEvent | ThreadMovedToInboxEvent | ThreadTrashedEvent | ThreadRestoredEvent;
+        export interface TimelineLinkedEntity {
+            entity_id: string;
+            /**
+             * Entity schema slug, e.g. "opportunity"
+             */
+            schema?: string;
+        }
+        export interface UnreadCountBuckets {
+            /**
+             * example:
+             * 14
+             */
+            unread: number;
+            /**
+             * Organization scope only.
+             * example:
+             * 12
+             */
+            drafts?: number;
+            /**
+             * Organization scope only.
+             * example:
+             * 1
+             */
+            unassigned?: number;
+            /**
+             * Organization scope only.
+             * example:
+             * 3
+             */
+            spam?: number;
+        }
+        export interface UnreadCountScope {
+            /**
+             * Caller-chosen key for this scope. Echoed back as the key in `counts`, so it is how the
+             * caller matches a number to the sidebar row it belongs to. Must be unique within the
+             * request; duplicates are refused rather than silently collapsed.
+             *
+             * example:
+             * inbox-support
+             */
+            name: string;
+            /**
+             * Decides which buckets come back, and whether `q` is required. `organization` returns all
+             * four buckets from the canonical central-inbox queries and takes no `q`. `shared_inbox`
+             * and `saved_view` return `unread` alone and require the `q` their list uses.
+             *
+             * A `shared_inbox` scope additionally requires `actor: organization` and is refused with a
+             * 400 otherwise. A shared inbox is an organization-level construct — selecting one always
+             * switches the mailbox to the organization — so it has no per-user read state and the
+             * combination would compute a number no surface renders. `saved_view` accepts either actor,
+             * because a view's own configuration names its mailbox.
+             *
+             */
+            type: "organization" | "shared_inbox" | "saved_view";
+            /**
+             * The scope's own list predicate, in Lucene syntax, exactly as the caller passes it to
+             * `threads:search`. Required for `shared_inbox` and `saved_view`, rejected for
+             * `organization`. The server ANDs the read-state condition onto it and nothing else, which
+             * is what makes the count and the list agree. Until the predicate definition moves
+             * server-side, this is the caller's authored copy.
+             *
+             * example:
+             * _tags.keyword:inbox AND !_tags.keyword:trash
+             */
+            q?: string;
+            /**
+             * Shared inbox ids, resolved to bucket ids the same way `threads:search` resolves them.
+             */
+            inbox_id?: /* Shared inbox ids, resolved to bucket ids the same way `threads:search` resolves them. */ string | string[];
+        }
+        export interface UnreadCountsPayload {
+            /**
+             * Which read state to count against — the org's or the calling user's. Same meaning as
+             * `getUnread`'s path parameter, and unrelated to a scope's `type`.
+             *
+             */
+            actor: "organization" | "user";
+            /**
+             * Restrict every scope to messages involving these addresses.
+             */
+            email_filter?: string[];
+            scopes: [
+                UnreadCountScope,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?,
+                UnreadCountScope?
+            ];
+        }
+        export interface UnreadCountsResult {
+            /**
+             * False when the `message-unread-counts` flag is off for the calling org, in which case
+             * `counts` is empty and no Elasticsearch work was done. Callers render no badges rather
+             * than rendering zeroes.
+             *
+             * example:
+             * true
+             */
+            enabled: boolean;
+            /**
+             * One entry per scope, keyed by the scope's `name`. A scope whose predicate could not be
+             * built is **absent** rather than zero, because a zero badge is a claim about the mailbox
+             * and an absent one is a claim about the request.
+             *
+             */
+            counts: {
+                [name: string]: UnreadCountBuckets;
+            };
+            /**
+             * Names of scopes that were accepted but could not be counted — today, a shared inbox whose
+             * ids matched no bucket in this org. Listed explicitly so a caller can tell an omission apart
+             * from a mis-spelled scope name, both of which are otherwise just a missing key in `counts`.
+             *
+             */
+            omitted?: string[];
+        }
+        export interface WorkflowStartedEvent {
+            type: "WORKFLOW_STARTED";
+            /**
+             * ID of the workflow/flow execution that was started
+             */
+            workflow_id?: string;
+            /**
+             * Name of the workflow that was started
+             */
+            workflow_name?: string;
+        }
     }
 }
 declare namespace Paths {
@@ -1467,6 +1708,16 @@ declare namespace Paths {
                  * 3
                  */
                 spam?: number;
+            }
+            export interface $403 {
+            }
+        }
+    }
+    namespace GetUnreadCounts {
+        export type RequestBody = Components.Schemas.UnreadCountsPayload;
+        namespace Responses {
+            export type $200 = Components.Schemas.UnreadCountsResult;
+            export interface $400 {
             }
             export interface $403 {
             }
@@ -2977,6 +3228,35 @@ export interface OperationMethods {
     config?: AxiosRequestConfig  
   ): OperationResponse<Paths.GetUnread.Responses.$200>
   /**
+   * getUnreadCounts - getUnreadCounts
+   * 
+   * Unread counts for several named scopes in one request.
+   * 
+   * A scope is a name plus the same parameters the thread list already takes (`q`, `inbox_id`),
+   * so a scope's count and the list beneath it are the same predicate and agree by construction.
+   * The server adds only the read-state condition; it does not re-author the caller's view.
+   * 
+   * The `organization` scope is the exception and takes no `q`: it reuses the four canonical
+   * central-inbox queries, so its numbers match `getUnread` exactly.
+   * 
+   * Buckets are not symmetric, across scope types or across actors. Every scope other than
+   * `organization` returns `unread` alone. The `organization` scope returns all four
+   * (`unread`, `drafts`, `unassigned`, `spam`) for `actor: organization`, and only `unread` and
+   * `drafts` for `actor: user` — the agent sidebar has no Spam or Unlinked folder, so those two
+   * numbers have nowhere to render and each one costs a cardinality aggregation. This is a
+   * deliberate divergence from `getUnread`, which computes all four for both actors.
+   * 
+   * Gated on the `message-unread-counts` flag, evaluated once per request against the calling
+   * org. With the flag off the response is `{ "enabled": false, "counts": {} }` and no
+   * Elasticsearch query is issued.
+   * 
+   */
+  'getUnreadCounts'(
+    parameters?: Parameters<UnknownParamsObject> | null,
+    data?: Paths.GetUnreadCounts.RequestBody,
+    config?: AxiosRequestConfig  
+  ): OperationResponse<Paths.GetUnreadCounts.Responses.$200>
+  /**
    * markUnreadMessageV2 - markUnreadMessageV2
    * 
    * Mark message as unread within a scope
@@ -3568,6 +3848,37 @@ export interface PathsDictionary {
       config?: AxiosRequestConfig  
     ): OperationResponse<Paths.GetUnread.Responses.$200>
   }
+  ['/v1/message/unread:counts']: {
+    /**
+     * getUnreadCounts - getUnreadCounts
+     * 
+     * Unread counts for several named scopes in one request.
+     * 
+     * A scope is a name plus the same parameters the thread list already takes (`q`, `inbox_id`),
+     * so a scope's count and the list beneath it are the same predicate and agree by construction.
+     * The server adds only the read-state condition; it does not re-author the caller's view.
+     * 
+     * The `organization` scope is the exception and takes no `q`: it reuses the four canonical
+     * central-inbox queries, so its numbers match `getUnread` exactly.
+     * 
+     * Buckets are not symmetric, across scope types or across actors. Every scope other than
+     * `organization` returns `unread` alone. The `organization` scope returns all four
+     * (`unread`, `drafts`, `unassigned`, `spam`) for `actor: organization`, and only `unread` and
+     * `drafts` for `actor: user` — the agent sidebar has no Spam or Unlinked folder, so those two
+     * numbers have nowhere to render and each one costs a cardinality aggregation. This is a
+     * deliberate divergence from `getUnread`, which computes all four for both actors.
+     * 
+     * Gated on the `message-unread-counts` flag, evaluated once per request against the calling
+     * org. With the flag off the response is `{ "enabled": false, "counts": {} }` and no
+     * Elasticsearch query is issued.
+     * 
+     */
+    'post'(
+      parameters?: Parameters<UnknownParamsObject> | null,
+      data?: Paths.GetUnreadCounts.RequestBody,
+      config?: AxiosRequestConfig  
+    ): OperationResponse<Paths.GetUnreadCounts.Responses.$200>
+  }
   ['/v2/message/messages/{id}/unread']: {
     /**
      * markUnreadMessageV2 - markUnreadMessageV2
@@ -4112,6 +4423,11 @@ export type ErrorResponse = Components.Schemas.ErrorResponse;
 export type FieldsParam = Components.Schemas.FieldsParam;
 export type File = Components.Schemas.File;
 export type Message = Components.Schemas.Message;
+export type MessageAutoReplySentEvent = Components.Schemas.MessageAutoReplySentEvent;
+export type MessageEntityLinkedEvent = Components.Schemas.MessageEntityLinkedEvent;
+export type MessageEntityUnlinkedEvent = Components.Schemas.MessageEntityUnlinkedEvent;
+export type MessageLabelAddedEvent = Components.Schemas.MessageLabelAddedEvent;
+export type MessageLabelRemovedEvent = Components.Schemas.MessageLabelRemovedEvent;
 export type MessageRequestParams = Components.Schemas.MessageRequestParams;
 export type MessageV2 = Components.Schemas.MessageV2;
 export type MoveThreadPayload = Components.Schemas.MoveThreadPayload;
@@ -4122,7 +4438,18 @@ export type SearchParams = Components.Schemas.SearchParams;
 export type SearchParamsV2 = Components.Schemas.SearchParamsV2;
 export type Thread = Components.Schemas.Thread;
 export type ThreadDoneEvent = Components.Schemas.ThreadDoneEvent;
+export type ThreadMovedToInboxEvent = Components.Schemas.ThreadMovedToInboxEvent;
 export type ThreadOpenEvent = Components.Schemas.ThreadOpenEvent;
+export type ThreadRestoredEvent = Components.Schemas.ThreadRestoredEvent;
 export type ThreadTimeline = Components.Schemas.ThreadTimeline;
+export type ThreadTrashedEvent = Components.Schemas.ThreadTrashedEvent;
+export type ThreadUserAssignedEvent = Components.Schemas.ThreadUserAssignedEvent;
+export type TimelineActor = Components.Schemas.TimelineActor;
 export type TimelineEvent = Components.Schemas.TimelineEvent;
 export type TimelineEventData = Components.Schemas.TimelineEventData;
+export type TimelineLinkedEntity = Components.Schemas.TimelineLinkedEntity;
+export type UnreadCountBuckets = Components.Schemas.UnreadCountBuckets;
+export type UnreadCountScope = Components.Schemas.UnreadCountScope;
+export type UnreadCountsPayload = Components.Schemas.UnreadCountsPayload;
+export type UnreadCountsResult = Components.Schemas.UnreadCountsResult;
+export type WorkflowStartedEvent = Components.Schemas.WorkflowStartedEvent;

--- a/clients/message-client/src/openapi.json
+++ b/clients/message-client/src/openapi.json
@@ -581,6 +581,44 @@
         }
       }
     },
+    "/v1/message/unread:counts": {
+      "post": {
+        "operationId": "getUnreadCounts",
+        "summary": "getUnreadCounts",
+        "description": "Unread counts for several named scopes in one request.\n\nA scope is a name plus the same parameters the thread list already takes (`q`, `inbox_id`),\nso a scope's count and the list beneath it are the same predicate and agree by construction.\nThe server adds only the read-state condition; it does not re-author the caller's view.\n\nThe `organization` scope is the exception and takes no `q`: it reuses the four canonical\ncentral-inbox queries, so its numbers match `getUnread` exactly.\n\nBuckets are not symmetric, across scope types or across actors. Every scope other than\n`organization` returns `unread` alone. The `organization` scope returns all four\n(`unread`, `drafts`, `unassigned`, `spam`) for `actor: organization`, and only `unread` and\n`drafts` for `actor: user` — the agent sidebar has no Spam or Unlinked folder, so those two\nnumbers have nowhere to render and each one costs a cardinality aggregation. This is a\ndeliberate divergence from `getUnread`, which computes all four for both actors.\n\nGated on the `message-unread-counts` flag, evaluated once per request against the calling\norg. With the flag off the response is `{ \"enabled\": false, \"counts\": {} }` and no\nElasticsearch query is issued.\n",
+        "tags": [
+          "Messages"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UnreadCountsPayload"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnreadCountsResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request names more scopes than the cap allows, repeats a scope name, or omits `q`\non a scope type that requires it. Over-cap requests are refused rather than truncated:\na silently dropped scope renders as a missing badge, which is indistinguishable from\nzero unread.\n"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    },
     "/v2/message/messages/{id}/unread": {
       "post": {
         "operationId": "markUnreadMessageV2",
@@ -2657,6 +2695,136 @@
           }
         }
       },
+      "UnreadCountScope": {
+        "type": "object",
+        "required": [
+          "name",
+          "type"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Caller-chosen key for this scope. Echoed back as the key in `counts`, so it is how the\ncaller matches a number to the sidebar row it belongs to. Must be unique within the\nrequest; duplicates are refused rather than silently collapsed.\n",
+            "example": "inbox-support"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "shared_inbox",
+              "saved_view"
+            ],
+            "description": "Decides which buckets come back, and whether `q` is required. `organization` returns all\nfour buckets from the canonical central-inbox queries and takes no `q`. `shared_inbox`\nand `saved_view` return `unread` alone and require the `q` their list uses.\n\nA `shared_inbox` scope additionally requires `actor: organization` and is refused with a\n400 otherwise. A shared inbox is an organization-level construct — selecting one always\nswitches the mailbox to the organization — so it has no per-user read state and the\ncombination would compute a number no surface renders. `saved_view` accepts either actor,\nbecause a view's own configuration names its mailbox.\n"
+          },
+          "q": {
+            "type": "string",
+            "description": "The scope's own list predicate, in Lucene syntax, exactly as the caller passes it to\n`threads:search`. Required for `shared_inbox` and `saved_view`, rejected for\n`organization`. The server ANDs the read-state condition onto it and nothing else, which\nis what makes the count and the list agree. Until the predicate definition moves\nserver-side, this is the caller's authored copy.\n",
+            "example": "_tags.keyword:inbox AND !_tags.keyword:trash"
+          },
+          "inbox_id": {
+            "description": "Shared inbox ids, resolved to bucket ids the same way `threads:search` resolves them.",
+            "oneOf": [
+              {
+                "type": "string",
+                "example": "3f34ce73-089c-4d45-a5ee-c161234e41c3"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "UnreadCountsPayload": {
+        "type": "object",
+        "required": [
+          "actor",
+          "scopes"
+        ],
+        "properties": {
+          "actor": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "user"
+            ],
+            "description": "Which read state to count against — the org's or the calling user's. Same meaning as\n`getUnread`'s path parameter, and unrelated to a scope's `type`.\n"
+          },
+          "email_filter": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Restrict every scope to messages involving these addresses."
+          },
+          "scopes": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 25,
+            "items": {
+              "$ref": "#/components/schemas/UnreadCountScope"
+            }
+          }
+        }
+      },
+      "UnreadCountsResult": {
+        "type": "object",
+        "required": [
+          "enabled",
+          "counts"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "False when the `message-unread-counts` flag is off for the calling org, in which case\n`counts` is empty and no Elasticsearch work was done. Callers render no badges rather\nthan rendering zeroes.\n",
+            "example": true
+          },
+          "counts": {
+            "type": "object",
+            "description": "One entry per scope, keyed by the scope's `name`. A scope whose predicate could not be\nbuilt is **absent** rather than zero, because a zero badge is a claim about the mailbox\nand an absent one is a claim about the request.\n",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/UnreadCountBuckets"
+            }
+          },
+          "omitted": {
+            "type": "array",
+            "description": "Names of scopes that were accepted but could not be counted — today, a shared inbox whose\nids matched no bucket in this org. Listed explicitly so a caller can tell an omission apart\nfrom a mis-spelled scope name, both of which are otherwise just a missing key in `counts`.\n",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UnreadCountBuckets": {
+        "type": "object",
+        "required": [
+          "unread"
+        ],
+        "properties": {
+          "unread": {
+            "type": "number",
+            "example": 14
+          },
+          "drafts": {
+            "type": "number",
+            "description": "Organization scope only.",
+            "example": 12
+          },
+          "unassigned": {
+            "type": "number",
+            "description": "Organization scope only.",
+            "example": 1
+          },
+          "spam": {
+            "type": "number",
+            "description": "Organization scope only.",
+            "example": 3
+          }
+        }
+      },
       "SearchParamsV2": {
         "type": "object",
         "required": [
@@ -2923,6 +3091,254 @@
           }
         }
       },
+      "WorkflowStartedEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "WORKFLOW_STARTED"
+            ]
+          },
+          "workflow_id": {
+            "type": "string",
+            "description": "ID of the workflow/flow execution that was started"
+          },
+          "workflow_name": {
+            "type": "string",
+            "description": "Name of the workflow that was started"
+          }
+        }
+      },
+      "ThreadUserAssignedEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "THREAD_USER_ASSIGNED"
+            ]
+          },
+          "added": {
+            "type": "array",
+            "description": "User IDs assigned to the thread",
+            "items": {
+              "type": "string"
+            }
+          },
+          "removed": {
+            "type": "array",
+            "description": "User IDs unassigned from the thread",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "MessageLabelAddedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "label"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MESSAGE_LABEL_ADDED"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "The label that was added (raw tag slug, e.g. `sentiments:angry`)"
+          },
+          "label_name": {
+            "type": "string",
+            "description": "Resolved taxonomy classification display name (e.g. `Verärgert`), when the label is a classification. Absent for free-form tags."
+          }
+        }
+      },
+      "MessageLabelRemovedEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "label"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MESSAGE_LABEL_REMOVED"
+            ]
+          },
+          "label": {
+            "type": "string",
+            "description": "The label that was removed (raw tag slug, e.g. `sentiments:angry`)"
+          },
+          "label_name": {
+            "type": "string",
+            "description": "Resolved taxonomy classification display name (e.g. `Verärgert`), when the label is a classification. Absent for free-form tags."
+          }
+        }
+      },
+      "MessageEntityLinkedEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MESSAGE_ENTITY_LINKED"
+            ]
+          },
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimelineLinkedEntity"
+            }
+          },
+          "link_kind": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "auto"
+            ]
+          }
+        }
+      },
+      "MessageEntityUnlinkedEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MESSAGE_ENTITY_UNLINKED"
+            ]
+          },
+          "entities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimelineLinkedEntity"
+            }
+          },
+          "link_kind": {
+            "type": "string",
+            "enum": [
+              "manual",
+              "auto"
+            ]
+          }
+        }
+      },
+      "MessageAutoReplySentEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MESSAGE_AUTO_REPLY_SENT"
+            ]
+          },
+          "reply_message_id": {
+            "type": "string",
+            "description": "ID of the message that was sent as the automatic reply"
+          },
+          "parent_message_id": {
+            "type": "string",
+            "description": "ID of the message the automatic reply responded to"
+          }
+        }
+      },
+      "ThreadMovedToInboxEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "THREAD_MOVED_TO_INBOX"
+            ]
+          },
+          "target_inbox_id": {
+            "type": "string",
+            "description": "ID of the shared inbox the thread was moved to"
+          },
+          "target_inbox_name": {
+            "type": "string",
+            "description": "Name of the shared inbox the thread was moved to"
+          }
+        }
+      },
+      "ThreadTrashedEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "THREAD_TRASHED"
+            ]
+          }
+        }
+      },
+      "ThreadRestoredEvent": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "THREAD_RESTORED"
+            ]
+          }
+        }
+      },
+      "TimelineLinkedEntity": {
+        "type": "object",
+        "required": [
+          "entity_id"
+        ],
+        "properties": {
+          "entity_id": {
+            "type": "string"
+          },
+          "schema": {
+            "type": "string",
+            "description": "Entity schema slug, e.g. \"opportunity\""
+          }
+        }
+      },
+      "TimelineActor": {
+        "type": "object",
+        "properties": {
+          "user_id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          }
+        }
+      },
       "TimelineEventData": {
         "type": "object",
         "discriminator": {
@@ -2934,6 +3350,36 @@
           },
           {
             "$ref": "#/components/schemas/ThreadOpenEvent"
+          },
+          {
+            "$ref": "#/components/schemas/WorkflowStartedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadUserAssignedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessageLabelAddedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessageLabelRemovedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessageEntityLinkedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessageEntityUnlinkedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/MessageAutoReplySentEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadMovedToInboxEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadTrashedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/ThreadRestoredEvent"
           }
         ]
       },
@@ -2944,13 +3390,47 @@
           "data"
         ],
         "properties": {
+          "id": {
+            "type": "string",
+            "description": "Activity id (ActivityItem._id), for deep-linking to the item in the activity feed"
+          },
           "data": {
             "$ref": "#/components/schemas/TimelineEventData"
           },
           "timestamp": {
             "type": "string",
             "description": "Timestamp of the event",
-            "example": "2024-01-01T00:00:00.000Z"
+            "example": "2024-01-01T00:00:00Z"
+          },
+          "message_id": {
+            "type": "string",
+            "description": "For message-level events, the message the activity is anchored to"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "user",
+              "automation",
+              "system"
+            ]
+          },
+          "automated": {
+            "type": "boolean",
+            "description": "Whether the activity was performed automatically (automation/system)"
+          },
+          "actor": {
+            "$ref": "#/components/schemas/TimelineActor"
+          },
+          "automation": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Adds `getUnreadCounts` to `@epilot/message-client` for the consolidated unread-counts endpoint merged in svc-centralized-message-api !466.

`POST /v1/message/unread:counts` returns unread counts for several named scopes in one request. A scope is a name plus the parameters the thread list already takes (`q`, `inbox_id`), and the server adds only the read-state condition — so a badge and the list beneath it are one predicate rather than two authored copies, and they agree by construction instead of by diligence. The `organization` scope is the exception and takes no `q`: it reuses the four canonical central-inbox queries so its numbers match `getUnread` exactly.

Gated on the `message-unread-counts` flag. With it off the response is `{ "enabled": false, "counts": {} }` and no Elasticsearch query is issued.

## Generated from the merged spec, not from prod

`npm run openapi` defaults to `https://docs.api.epilot.io/message.yaml`, which does not carry this operation yet — the API MR is merged but not deployed. So this used the documented local-spec path against the API repo's `main`.

That is worth a second look on review, because it means the client's spec now comes from a source other than prod. Checked before committing, operation by operation: **one operationId added (`getUnreadCounts`), none removed, none changed**, 53 → 54. The rest of the diff is that endpoint's request and response schemas.

The consumer is epilot360-messaging !1219, which currently posts through the raw axios instance because there was no typed method. Once this publishes, that becomes a one-line swap to `client.getUnreadCounts` and the types come from the package instead of being transcribed into the MFE.

## Verification

- `npm run typegen && npm run build` clean; `biome check src` clean
- `getUnreadCounts` present in `src/openapi.d.ts` as both a client operation method and a path operation, typed `Paths.GetUnreadCounts.RequestBody` → `Paths.GetUnreadCounts.Responses.$200`
- Changeset included as a `minor` bump: new operation, nothing removed or changed

Not done here: no npm publish. `pnpm version-packages` and `pnpm publish-packages` need 2FA.