### PR TITLE
chore(calendar-client): update OpenAPI definitions

### DIFF
--- a/clients/calendar-client/src/openapi.d.ts
+++ b/clients/calendar-client/src/openapi.d.ts
@@ -119,9 +119,13 @@ declare namespace Components {
              */
             color?: string | null;
             /**
-             * True if this is the user's primary calendar
+             * True if the source provider marks this calendar as default
              */
             is_default: boolean;
+            /**
+             * True for the epilot default calendar
+             */
+            is_epilot_default: boolean;
             /**
              * True if the caller cannot create, update, or delete events in this calendar
              */
@@ -221,9 +225,9 @@ declare namespace Components {
         }
         export interface CalendarEventCreateBody {
             /**
-             * epilot calendar this event belongs to
+             * Owned calendar ID. Omit this property to use the epilot default calendar.
              */
-            calendar_id: string;
+            calendar_id?: string;
             /**
              * Preview of the event body, truncated to 255 chars
              */
@@ -1272,6 +1276,7 @@ declare namespace Paths {
             export interface $204 {
             }
             export type $404 = Components.Schemas.Error;
+            export type $409 = Components.Schemas.Error;
         }
     }
     namespace DeleteEvent {
@@ -1941,7 +1946,7 @@ export interface OperationMethods {
   /**
    * createEvent - createEvent
    * 
-   * Create a native epilot calendar event.
+   * Create a native epilot calendar event. Omit `calendar_id` to use the caller’s epilot default calendar.
    */
   'createEvent'(
     parameters?: Parameters<UnknownParamsObject> | null,
@@ -2270,7 +2275,7 @@ export interface PathsDictionary {
     /**
      * createEvent - createEvent
      * 
-     * Create a native epilot calendar event.
+     * Create a native epilot calendar event. Omit `calendar_id` to use the caller’s epilot default calendar.
      */
     'post'(
       parameters?: Parameters<UnknownParamsObject> | null,

--- a/clients/calendar-client/src/openapi.json
+++ b/clients/calendar-client/src/openapi.json
@@ -1328,6 +1328,16 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "The epilot default calendar cannot be deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
@@ -1430,7 +1440,7 @@
       "post": {
         "operationId": "createEvent",
         "summary": "createEvent",
-        "description": "Create a native epilot calendar event.",
+        "description": "Create a native epilot calendar event. Omit `calendar_id` to use the caller’s epilot default calendar.",
         "tags": [
           "Calendar Events"
         ],
@@ -2323,7 +2333,11 @@
           },
           "is_default": {
             "type": "boolean",
-            "description": "True if this is the user's primary calendar"
+            "description": "True if the source provider marks this calendar as default"
+          },
+          "is_epilot_default": {
+            "type": "boolean",
+            "description": "True for the epilot default calendar"
           },
           "read_only": {
             "type": "boolean",
@@ -2352,6 +2366,7 @@
           "_org",
           "name",
           "is_default",
+          "is_epilot_default",
           "read_only",
           "source"
         ]
@@ -2768,7 +2783,7 @@
           "calendar_id": {
             "type": "string",
             "minLength": 1,
-            "description": "epilot calendar this event belongs to"
+            "description": "Owned calendar ID. Omit this property to use the epilot default calendar."
           },
           "description": {
             "type": "string",
@@ -2815,7 +2830,6 @@
           }
         },
         "required": [
-          "calendar_id",
           "start_time",
           "end_time",
           "timezone",


### PR DESCRIPTION
## Summary

- update the Calendar API schema for epilot default calendars
- expose `is_epilot_default` and allow event creation without `calendar_id`
- document the conflict response when deleting the epilot default calendar