### PR TITLE
feat(message-client): add ThreadView and the structured-view params

### DIFF
--- a/.changeset/message-client-thread-view.md
+++ b/.changeset/message-client-thread-view.md
@@ -1,0 +1,11 @@
+---
+"@epilot/message-client": minor
+---
+
+Add `ThreadView` and the structured-view parameters for server-side predicate compilation
+
+`threads:search` and `threads:searchIds` accept a `view` describing a central-inbox view structurally — folder, mailbox, labels, purposes, state filters, from/to, assignees, date range, free text — which the service compiles to a query, so a view's list and its unread count are one predicate rather than two hand-authored copies. `user_groups` travels alongside it, because the caller's groups live on the access token rather than the id token the service parses.
+
+`q` becomes optional on `SearchParamsV2` and `SearchIDParams`: a caller sends either predicate. Requests naming neither are refused by the service, and an empty-string `q` behaves as before.
+
+`UnreadCountScope` gains `view_id`, so a count scope names the saved view it counts instead of restating that view's predicate on the wire.

--- a/clients/message-client/src/openapi.d.ts
+++ b/clients/message-client/src/openapi.d.ts
@@ -657,6 +657,102 @@ declare namespace Components {
          */
         export type ReadingScope = "organization" | "user";
         export interface SearchIDParams {
+            /**
+             * The view to compile, with the same meaning as on `threads:search`. Present here because
+             * this endpoint returns the ordered id set *for that list*: if one compiled its view and the
+             * other ran an authored `q`, the two would disagree inside a single feature, which is the
+             * drift this replaces.
+             *
+             */
+            view?: {
+                [name: string]: any;
+                /**
+                 * Which sidebar folder's membership predicate to apply.
+                 */
+                folder?: "inbox" | "favorite" | "sent" | "trash" | "spam" | "unassignable" | "draft";
+                /**
+                 * Whose mailbox this is. `agent` scopes to threads assigned to the caller or their groups;
+                 * `organization` scopes to the org and is the only mailbox that carries address filtering.
+                 *
+                 */
+                mailbox?: "organization" | "agent";
+                /**
+                 * Saved-filter labels, ANDed. Matched exactly against the tag rather than against its
+                 * tokens, so a label whose words overlap a folder tag no longer lands in that folder.
+                 *
+                 */
+                labels?: string[];
+                /**
+                 * Purpose ids on linked entities, ANDed.
+                 */
+                purposes?: string[];
+                /**
+                 * State filters, independent of the folder. `resolved` and `trash` reach the Inbox folder
+                 * only and are mutually exclusive there; `unread` applies anywhere.
+                 *
+                 */
+                filters?: ("unread" | "resolved" | "trash")[];
+                /**
+                 * Sender addresses to filter on.
+                 */
+                from?: string[];
+                /**
+                 * Recipient addresses to filter on.
+                 */
+                to?: string[];
+                /**
+                 * Assignee user ids.
+                 */
+                assigned_to?: string[];
+                /**
+                 * Whether threads with no assignee join the `assigned_to` set. A separate flag rather than a
+                 * sentinel entry in that list, so `assigned_to` holds user ids and nothing else.
+                 *
+                 */
+                include_unassigned?: boolean;
+                /**
+                 * Lower bound of the date range, in days before now. Omitted means the epoch.
+                 */
+                date_from_days_ago?: number;
+                /**
+                 * Upper bound of the date range, in days before now. Omitted means now.
+                 */
+                date_to_days_ago?: number;
+                /**
+                 * Addresses the user selected in the address filter. Absent and empty differ, and the
+                 * difference is a real UI state: absent is "not filtering by address", empty is "every
+                 * address deselected", which matches nothing.
+                 *
+                 * Distinct from the permission restriction, which the server derives and a caller cannot
+                 * author.
+                 *
+                 */
+                email_filter?: string[];
+                /**
+                 * The user's search string, as typed. Expanded across the searched fields server-side and
+                 * never interpreted as query syntax, so a typed operator or a stray bracket cannot
+                 * re-associate the predicate around it.
+                 *
+                 */
+                text?: string;
+                /**
+                 * Restrict the view to these threads. Exists because "would this thread appear in the view
+                 * the user is looking at?" is a real question the inbox asks when a new thread arrives, and
+                 * it is a membership test against the view rather than a different view.
+                 *
+                 */
+                thread_ids?: string[];
+                /**
+                 * Restrict the view to threads this user pinned. The pinned strip above the list is the same
+                 * view with this one extra condition.
+                 *
+                 */
+                pinned_by?: string;
+            };
+            /**
+             * The caller's group ids, with the same meaning and caveats as on `threads:search`.
+             */
+            user_groups?: string[];
             inbox_id?: string | string[];
             /**
              * Lucene query syntax supported with ElasticSearch
@@ -679,11 +775,127 @@ declare namespace Components {
         export interface SearchParamsV2 {
             inbox_id?: string | string[];
             /**
-             * Lucene query syntax supported with ElasticSearch
+             * Lucene query syntax supported with ElasticSearch.
+             *
+             * Send this or `view`, not both. At least one is required; a request with neither is refused
+             * with a 400. An empty string is accepted and returns no hits.
+             *
              * example:
              * subject:"Request for solar panel price" AND _tags:INBOX
              */
-            q: string;
+            q?: string;
+            /**
+             * A view for the server to compile into the query, instead of supplying `q`. When a view is
+             * present and compilation is enabled for the calling organization, the compiled query runs and
+             * `q` is not consulted.
+             *
+             * Read by `threads:search` and `threads:searchIds` only. This schema is shared with
+             * `messages:search`, which compiles no view and ignores the field, so a request there must
+             * supply `q`.
+             *
+             * Compilation is enabled per organization by the `message-unread-unified-predicate` feature
+             * flag. While it is off, `q` runs and a request supplying only a view returns no hits.
+             *
+             */
+            view?: {
+                [name: string]: any;
+                /**
+                 * Which sidebar folder's membership predicate to apply.
+                 */
+                folder?: "inbox" | "favorite" | "sent" | "trash" | "spam" | "unassignable" | "draft";
+                /**
+                 * Whose mailbox this is. `agent` scopes to threads assigned to the caller or their groups;
+                 * `organization` scopes to the org and is the only mailbox that carries address filtering.
+                 *
+                 */
+                mailbox?: "organization" | "agent";
+                /**
+                 * Saved-filter labels, ANDed. Matched exactly against the tag rather than against its
+                 * tokens, so a label whose words overlap a folder tag no longer lands in that folder.
+                 *
+                 */
+                labels?: string[];
+                /**
+                 * Purpose ids on linked entities, ANDed.
+                 */
+                purposes?: string[];
+                /**
+                 * State filters, independent of the folder. `resolved` and `trash` reach the Inbox folder
+                 * only and are mutually exclusive there; `unread` applies anywhere.
+                 *
+                 */
+                filters?: ("unread" | "resolved" | "trash")[];
+                /**
+                 * Sender addresses to filter on.
+                 */
+                from?: string[];
+                /**
+                 * Recipient addresses to filter on.
+                 */
+                to?: string[];
+                /**
+                 * Assignee user ids.
+                 */
+                assigned_to?: string[];
+                /**
+                 * Whether threads with no assignee join the `assigned_to` set. A separate flag rather than a
+                 * sentinel entry in that list, so `assigned_to` holds user ids and nothing else.
+                 *
+                 */
+                include_unassigned?: boolean;
+                /**
+                 * Lower bound of the date range, in days before now. Omitted means the epoch.
+                 */
+                date_from_days_ago?: number;
+                /**
+                 * Upper bound of the date range, in days before now. Omitted means now.
+                 */
+                date_to_days_ago?: number;
+                /**
+                 * Addresses the user selected in the address filter. Absent and empty differ, and the
+                 * difference is a real UI state: absent is "not filtering by address", empty is "every
+                 * address deselected", which matches nothing.
+                 *
+                 * Distinct from the permission restriction, which the server derives and a caller cannot
+                 * author.
+                 *
+                 */
+                email_filter?: string[];
+                /**
+                 * The user's search string, as typed. Expanded across the searched fields server-side and
+                 * never interpreted as query syntax, so a typed operator or a stray bracket cannot
+                 * re-associate the predicate around it.
+                 *
+                 */
+                text?: string;
+                /**
+                 * Restrict the view to these threads. Exists because "would this thread appear in the view
+                 * the user is looking at?" is a real question the inbox asks when a new thread arrives, and
+                 * it is a membership test against the view rather than a different view.
+                 *
+                 */
+                thread_ids?: string[];
+                /**
+                 * Restrict the view to threads this user pinned. The pinned strip above the list is the same
+                 * view with this one extra condition.
+                 *
+                 */
+                pinned_by?: string;
+            };
+            /**
+             * The caller's group ids, as `group_<id>`. Read only when a `view` is compiled, where they
+             * determine the agent mailbox's assignee condition and which shared inboxes, and therefore
+             * which addresses, are reachable. Required for those conditions to be correct, because group
+             * membership is not present on the id token this service parses.
+             *
+             * Entries not matching `group_<id>` are dropped.
+             *
+             * Not an authorization input, and not treated as one: naming groups the caller is not in
+             * widens what the response includes, exactly as supplying a broader `q` does. Access control
+             * is enforced elsewhere.
+             *
+             */
+            user_groups?: string[];
             fields?: /**
              * List of entity fields to include or exclude in the response
              *
@@ -813,6 +1025,100 @@ declare namespace Components {
              */
             removed?: string[];
         }
+        /**
+         * A central-inbox view, described structurally so the server compiles the query for it. Both the
+         * thread list and the unread count for a view are compiled from the same description, so the two
+         * cannot disagree about what the view means.
+         *
+         * Every field is optional and an omitted field adds no condition, so a view narrows the whole
+         * mailbox rather than being a template with required holes. Unknown fields are ignored.
+         *
+         */
+        export interface ThreadView {
+            [name: string]: any;
+            /**
+             * Which sidebar folder's membership predicate to apply.
+             */
+            folder?: "inbox" | "favorite" | "sent" | "trash" | "spam" | "unassignable" | "draft";
+            /**
+             * Whose mailbox this is. `agent` scopes to threads assigned to the caller or their groups;
+             * `organization` scopes to the org and is the only mailbox that carries address filtering.
+             *
+             */
+            mailbox?: "organization" | "agent";
+            /**
+             * Saved-filter labels, ANDed. Matched exactly against the tag rather than against its
+             * tokens, so a label whose words overlap a folder tag no longer lands in that folder.
+             *
+             */
+            labels?: string[];
+            /**
+             * Purpose ids on linked entities, ANDed.
+             */
+            purposes?: string[];
+            /**
+             * State filters, independent of the folder. `resolved` and `trash` reach the Inbox folder
+             * only and are mutually exclusive there; `unread` applies anywhere.
+             *
+             */
+            filters?: ("unread" | "resolved" | "trash")[];
+            /**
+             * Sender addresses to filter on.
+             */
+            from?: string[];
+            /**
+             * Recipient addresses to filter on.
+             */
+            to?: string[];
+            /**
+             * Assignee user ids.
+             */
+            assigned_to?: string[];
+            /**
+             * Whether threads with no assignee join the `assigned_to` set. A separate flag rather than a
+             * sentinel entry in that list, so `assigned_to` holds user ids and nothing else.
+             *
+             */
+            include_unassigned?: boolean;
+            /**
+             * Lower bound of the date range, in days before now. Omitted means the epoch.
+             */
+            date_from_days_ago?: number;
+            /**
+             * Upper bound of the date range, in days before now. Omitted means now.
+             */
+            date_to_days_ago?: number;
+            /**
+             * Addresses the user selected in the address filter. Absent and empty differ, and the
+             * difference is a real UI state: absent is "not filtering by address", empty is "every
+             * address deselected", which matches nothing.
+             *
+             * Distinct from the permission restriction, which the server derives and a caller cannot
+             * author.
+             *
+             */
+            email_filter?: string[];
+            /**
+             * The user's search string, as typed. Expanded across the searched fields server-side and
+             * never interpreted as query syntax, so a typed operator or a stray bracket cannot
+             * re-associate the predicate around it.
+             *
+             */
+            text?: string;
+            /**
+             * Restrict the view to these threads. Exists because "would this thread appear in the view
+             * the user is looking at?" is a real question the inbox asks when a new thread arrives, and
+             * it is a membership test against the view rather than a different view.
+             *
+             */
+            thread_ids?: string[];
+            /**
+             * Restrict the view to threads this user pinned. The pinned strip above the list is the same
+             * view with this one extra condition.
+             *
+             */
+            pinned_by?: string;
+        }
         export interface TimelineActor {
             user_id?: string;
             email?: string;
@@ -826,7 +1132,7 @@ declare namespace Components {
             /**
              * Timestamp of the event
              * example:
-             * 2024-01-01T00:00:00Z
+             * 2024-01-01T00:00:00.000Z
              */
             timestamp: string;
             /**
@@ -890,7 +1196,8 @@ declare namespace Components {
             /**
              * Decides which buckets come back, and whether `q` is required. `organization` returns all
              * four buckets from the canonical central-inbox queries and takes no `q`. `shared_inbox`
-             * and `saved_view` return `unread` alone and require the `q` their list uses.
+             * and `saved_view` return `unread` alone. A `saved_view` scope names its view with `view_id`;
+             * a `shared_inbox` scope needs only its `inbox_id`, since the query follows from the type.
              *
              * A `shared_inbox` scope additionally requires `actor: organization` and is refused with a
              * 400 otherwise. A shared inbox is an organization-level construct — selecting one always
@@ -901,16 +1208,40 @@ declare namespace Components {
              */
             type: "organization" | "shared_inbox" | "saved_view";
             /**
-             * The scope's own list predicate, in Lucene syntax, exactly as the caller passes it to
-             * `threads:search`. Required for `shared_inbox` and `saved_view`, rejected for
-             * `organization`. The server ANDs the read-state condition onto it and nothing else, which
-             * is what makes the count and the list agree. Until the predicate definition moves
-             * server-side, this is the caller's authored copy.
+             * The scope's query, in Lucene syntax, as passed to `threads:search` for the same scope. The
+             * server adds the read-state condition and nothing else, so the count matches that list.
+             *
+             * Accepted for `shared_inbox` and `saved_view`; rejected for `organization`.
+             *
+             * Superseded by server-side compilation. It remains accepted for callers whose counts are
+             * enabled while compilation is not, and is ignored when compilation is enabled. It will be
+             * removed once compilation is enabled everywhere counts are.
              *
              * example:
              * _tags.keyword:inbox AND !_tags.keyword:trash
              */
             q?: string;
+            /**
+             * The id of the saved view this scope counts. The server reads that view and compiles the same
+             * query the thread list runs for it, so the count and the list cannot describe the view
+             * differently.
+             *
+             * Required for `saved_view` scopes unless `q` is supplied instead; rejected for the other two
+             * types. A `shared_inbox` scope needs no predicate field at all, because its query follows from
+             * the type and its `inbox_id`. An `organization` scope uses the canonical folder queries.
+             *
+             * The view's own shared-inbox filter is read from the stored view, so `inbox_id` need not be
+             * sent alongside this.
+             *
+             * Compilation is enabled per organization by the `message-unread-unified-predicate` feature
+             * flag. While it is off, a scope supplying only a `view_id` has no query to run and its name is
+             * returned in `omitted` rather than counted. A named view that this organization does not have,
+             * or whose stored configuration cannot be read, is omitted the same way.
+             *
+             * example:
+             * 3f34ce73-089c-4d45-a5ee-c161234e41c3
+             */
+            view_id?: string;
             /**
              * Shared inbox ids, resolved to bucket ids the same way `threads:search` resolves them.
              */
@@ -927,6 +1258,13 @@ declare namespace Components {
              * Restrict every scope to messages involving these addresses.
              */
             email_filter?: string[];
+            /**
+             * The caller's group ids, as `group_<id>`, with the same meaning and constraints as on
+             * `threads:search`. Read only when a scope carries a `view`. Entries not matching
+             * `group_<id>` are dropped. Not an authorization input.
+             *
+             */
+            user_groups?: string[];
             scopes: [
                 UnreadCountScope,
                 UnreadCountScope?,
@@ -975,9 +1313,13 @@ declare namespace Components {
                 [name: string]: UnreadCountBuckets;
             };
             /**
-             * Names of scopes that were accepted but could not be counted — today, a shared inbox whose
-             * ids matched no bucket in this org. Listed explicitly so a caller can tell an omission apart
-             * from a mis-spelled scope name, both of which are otherwise just a missing key in `counts`.
+             * Names of scopes that were accepted but could not be counted. Each appears here and is
+             * absent from `counts`, so an omission is distinguishable from a mis-spelled scope name.
+             *
+             * Causes, not distinguishable from this field: a `shared_inbox` scope whose ids matched no
+             * bucket in the organization; a scope with no query to run because compilation is disabled for
+             * the organization and no `q` was supplied; and a `view_id` naming a view this organization
+             * does not have or whose stored configuration cannot be read.
              *
              */
             omitted?: string[];
@@ -3239,12 +3581,11 @@ export interface OperationMethods {
    * The `organization` scope is the exception and takes no `q`: it reuses the four canonical
    * central-inbox queries, so its numbers match `getUnread` exactly.
    * 
-   * Buckets are not symmetric, across scope types or across actors. Every scope other than
-   * `organization` returns `unread` alone. The `organization` scope returns all four
-   * (`unread`, `drafts`, `unassigned`, `spam`) for `actor: organization`, and only `unread` and
-   * `drafts` for `actor: user` — the agent sidebar has no Spam or Unlinked folder, so those two
-   * numbers have nowhere to render and each one costs a cardinality aggregation. This is a
-   * deliberate divergence from `getUnread`, which computes all four for both actors.
+   * Which buckets come back varies by scope type and actor. Every scope other than `organization`
+   * returns `unread` alone. An `organization` scope returns all four (`unread`, `drafts`,
+   * `unassigned`, `spam`) for `actor: organization`, and `unread` and `drafts` only for
+   * `actor: user`. `getUnread` returns all four for both actors; this endpoint omits the two that
+   * no per-user surface renders, since each costs an aggregation.
    * 
    * Gated on the `message-unread-counts` flag, evaluated once per request against the calling
    * org. With the flag off the response is `{ "enabled": false, "counts": {} }` and no
@@ -3861,12 +4202,11 @@ export interface PathsDictionary {
      * The `organization` scope is the exception and takes no `q`: it reuses the four canonical
      * central-inbox queries, so its numbers match `getUnread` exactly.
      * 
-     * Buckets are not symmetric, across scope types or across actors. Every scope other than
-     * `organization` returns `unread` alone. The `organization` scope returns all four
-     * (`unread`, `drafts`, `unassigned`, `spam`) for `actor: organization`, and only `unread` and
-     * `drafts` for `actor: user` — the agent sidebar has no Spam or Unlinked folder, so those two
-     * numbers have nowhere to render and each one costs a cardinality aggregation. This is a
-     * deliberate divergence from `getUnread`, which computes all four for both actors.
+     * Which buckets come back varies by scope type and actor. Every scope other than `organization`
+     * returns `unread` alone. An `organization` scope returns all four (`unread`, `drafts`,
+     * `unassigned`, `spam`) for `actor: organization`, and `unread` and `drafts` only for
+     * `actor: user`. `getUnread` returns all four for both actors; this endpoint omits the two that
+     * no per-user surface renders, since each costs an aggregation.
      * 
      * Gated on the `message-unread-counts` flag, evaluated once per request against the calling
      * org. With the flag off the response is `{ "enabled": false, "counts": {} }` and no
@@ -4444,6 +4784,7 @@ export type ThreadRestoredEvent = Components.Schemas.ThreadRestoredEvent;
 export type ThreadTimeline = Components.Schemas.ThreadTimeline;
 export type ThreadTrashedEvent = Components.Schemas.ThreadTrashedEvent;
 export type ThreadUserAssignedEvent = Components.Schemas.ThreadUserAssignedEvent;
+export type ThreadView = Components.Schemas.ThreadView;
 export type TimelineActor = Components.Schemas.TimelineActor;
 export type TimelineEvent = Components.Schemas.TimelineEvent;
 export type TimelineEventData = Components.Schemas.TimelineEventData;

--- a/clients/message-client/src/openapi.json
+++ b/clients/message-client/src/openapi.json
@@ -585,7 +585,7 @@
       "post": {
         "operationId": "getUnreadCounts",
         "summary": "getUnreadCounts",
-        "description": "Unread counts for several named scopes in one request.\n\nA scope is a name plus the same parameters the thread list already takes (`q`, `inbox_id`),\nso a scope's count and the list beneath it are the same predicate and agree by construction.\nThe server adds only the read-state condition; it does not re-author the caller's view.\n\nThe `organization` scope is the exception and takes no `q`: it reuses the four canonical\ncentral-inbox queries, so its numbers match `getUnread` exactly.\n\nBuckets are not symmetric, across scope types or across actors. Every scope other than\n`organization` returns `unread` alone. The `organization` scope returns all four\n(`unread`, `drafts`, `unassigned`, `spam`) for `actor: organization`, and only `unread` and\n`drafts` for `actor: user` — the agent sidebar has no Spam or Unlinked folder, so those two\nnumbers have nowhere to render and each one costs a cardinality aggregation. This is a\ndeliberate divergence from `getUnread`, which computes all four for both actors.\n\nGated on the `message-unread-counts` flag, evaluated once per request against the calling\norg. With the flag off the response is `{ \"enabled\": false, \"counts\": {} }` and no\nElasticsearch query is issued.\n",
+        "description": "Unread counts for several named scopes in one request.\n\nA scope is a name plus the same parameters the thread list already takes (`q`, `inbox_id`),\nso a scope's count and the list beneath it are the same predicate and agree by construction.\nThe server adds only the read-state condition; it does not re-author the caller's view.\n\nThe `organization` scope is the exception and takes no `q`: it reuses the four canonical\ncentral-inbox queries, so its numbers match `getUnread` exactly.\n\nWhich buckets come back varies by scope type and actor. Every scope other than `organization`\nreturns `unread` alone. An `organization` scope returns all four (`unread`, `drafts`,\n`unassigned`, `spam`) for `actor: organization`, and `unread` and `drafts` only for\n`actor: user`. `getUnread` returns all four for both actors; this endpoint omits the two that\nno per-user surface renders, since each costs an aggregation.\n\nGated on the `message-unread-counts` flag, evaluated once per request against the calling\norg. With the flag off the response is `{ \"enabled\": false, \"counts\": {} }` and no\nElasticsearch query is issued.\n",
         "tags": [
           "Messages"
         ],
@@ -611,7 +611,7 @@
             }
           },
           "400": {
-            "description": "The request names more scopes than the cap allows, repeats a scope name, or omits `q`\non a scope type that requires it. Over-cap requests are refused rather than truncated:\na silently dropped scope renders as a missing badge, which is indistinguishable from\nzero unread.\n"
+            "description": "The request names more scopes than the cap allows, repeats a scope name, or omits both\n`q` and `view` on a scope type that needs a predicate. Over-cap requests are refused rather than truncated:\na silently dropped scope renders as a missing badge, which is indistinguishable from\nzero unread.\n"
           },
           "403": {
             "description": "Forbidden"
@@ -832,7 +832,7 @@
       "post": {
         "operationId": "getAssigneeWorkload",
         "summary": "getAssigneeWorkload",
-        "description": "Return the open-thread workload for a set of user ids.\n\nFor each requested user id, returns the number of *open* threads assigned\ndirectly to that user — matching what the user sees in their central-inbox\nopen view: in inbox, not trashed, not done, and excluding notification-only\nand spam threads.\n\nOnly threads assigned directly to a user are counted; threads assigned to a\ngroup the user belongs to are not. Intended for assignment load-balancing\n(e.g. even-distribution automations) that need a consistent, inbox-aligned\nworkload per user.\n",
+        "description": "Return the open-thread workload for a set of user ids.\n\nFor each requested user id, returns the number of *open* threads assigned\ndirectly to that user \u2014 matching what the user sees in their central-inbox\nopen view: in inbox, not trashed, not done, and excluding notification-only\nand spam threads.\n\nOnly threads assigned directly to a user are counted; threads assigned to a\ngroup the user belongs to are not. Intended for assignment load-balancing\n(e.g. even-distribution automations) that need a consistent, inbox-aligned\nworkload per user.\n",
         "tags": [
           "Threads"
         ],
@@ -2695,6 +2695,117 @@
           }
         }
       },
+      "ThreadView": {
+        "type": "object",
+        "additionalProperties": true,
+        "description": "A central-inbox view, described structurally so the server compiles the query for it. Both the\nthread list and the unread count for a view are compiled from the same description, so the two\ncannot disagree about what the view means.\n\nEvery field is optional and an omitted field adds no condition, so a view narrows the whole\nmailbox rather than being a template with required holes. Unknown fields are ignored.\n",
+        "properties": {
+          "folder": {
+            "type": "string",
+            "enum": [
+              "inbox",
+              "favorite",
+              "sent",
+              "trash",
+              "spam",
+              "unassignable",
+              "draft"
+            ],
+            "description": "Which sidebar folder's membership predicate to apply."
+          },
+          "mailbox": {
+            "type": "string",
+            "enum": [
+              "organization",
+              "agent"
+            ],
+            "description": "Whose mailbox this is. `agent` scopes to threads assigned to the caller or their groups;\n`organization` scopes to the org and is the only mailbox that carries address filtering.\n"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Saved-filter labels, ANDed. Matched exactly against the tag rather than against its\ntokens, so a label whose words overlap a folder tag no longer lands in that folder.\n"
+          },
+          "purposes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Purpose ids on linked entities, ANDed."
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "unread",
+                "resolved",
+                "trash"
+              ]
+            },
+            "description": "State filters, independent of the folder. `resolved` and `trash` reach the Inbox folder\nonly and are mutually exclusive there; `unread` applies anywhere.\n"
+          },
+          "from": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Sender addresses to filter on."
+          },
+          "to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Recipient addresses to filter on."
+          },
+          "assigned_to": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Assignee user ids."
+          },
+          "include_unassigned": {
+            "type": "boolean",
+            "description": "Whether threads with no assignee join the `assigned_to` set. A separate flag rather than a\nsentinel entry in that list, so `assigned_to` holds user ids and nothing else.\n"
+          },
+          "date_from_days_ago": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Lower bound of the date range, in days before now. Omitted means the epoch."
+          },
+          "date_to_days_ago": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Upper bound of the date range, in days before now. Omitted means now."
+          },
+          "email_filter": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Addresses the user selected in the address filter. Absent and empty differ, and the\ndifference is a real UI state: absent is \"not filtering by address\", empty is \"every\naddress deselected\", which matches nothing.\n\nDistinct from the permission restriction, which the server derives and a caller cannot\nauthor.\n"
+          },
+          "text": {
+            "type": "string",
+            "description": "The user's search string, as typed. Expanded across the searched fields server-side and\nnever interpreted as query syntax, so a typed operator or a stray bracket cannot\nre-associate the predicate around it.\n"
+          },
+          "thread_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Restrict the view to these threads. Exists because \"would this thread appear in the view\nthe user is looking at?\" is a real question the inbox asks when a new thread arrives, and\nit is a membership test against the view rather than a different view.\n"
+          },
+          "pinned_by": {
+            "type": "string",
+            "description": "Restrict the view to threads this user pinned. The pinned strip above the list is the same\nview with this one extra condition.\n"
+          }
+        }
+      },
       "UnreadCountScope": {
         "type": "object",
         "required": [
@@ -2714,12 +2825,17 @@
               "shared_inbox",
               "saved_view"
             ],
-            "description": "Decides which buckets come back, and whether `q` is required. `organization` returns all\nfour buckets from the canonical central-inbox queries and takes no `q`. `shared_inbox`\nand `saved_view` return `unread` alone and require the `q` their list uses.\n\nA `shared_inbox` scope additionally requires `actor: organization` and is refused with a\n400 otherwise. A shared inbox is an organization-level construct — selecting one always\nswitches the mailbox to the organization — so it has no per-user read state and the\ncombination would compute a number no surface renders. `saved_view` accepts either actor,\nbecause a view's own configuration names its mailbox.\n"
+            "description": "Decides which buckets come back, and whether `q` is required. `organization` returns all\nfour buckets from the canonical central-inbox queries and takes no `q`. `shared_inbox`\nand `saved_view` return `unread` alone. A `saved_view` scope names its view with `view_id`;\na `shared_inbox` scope needs only its `inbox_id`, since the query follows from the type.\n\nA `shared_inbox` scope additionally requires `actor: organization` and is refused with a\n400 otherwise. A shared inbox is an organization-level construct \u2014 selecting one always\nswitches the mailbox to the organization \u2014 so it has no per-user read state and the\ncombination would compute a number no surface renders. `saved_view` accepts either actor,\nbecause a view's own configuration names its mailbox.\n"
           },
           "q": {
             "type": "string",
-            "description": "The scope's own list predicate, in Lucene syntax, exactly as the caller passes it to\n`threads:search`. Required for `shared_inbox` and `saved_view`, rejected for\n`organization`. The server ANDs the read-state condition onto it and nothing else, which\nis what makes the count and the list agree. Until the predicate definition moves\nserver-side, this is the caller's authored copy.\n",
+            "description": "The scope's query, in Lucene syntax, as passed to `threads:search` for the same scope. The\nserver adds the read-state condition and nothing else, so the count matches that list.\n\nAccepted for `shared_inbox` and `saved_view`; rejected for `organization`.\n\nSuperseded by server-side compilation. It remains accepted for callers whose counts are\nenabled while compilation is not, and is ignored when compilation is enabled. It will be\nremoved once compilation is enabled everywhere counts are.\n",
             "example": "_tags.keyword:inbox AND !_tags.keyword:trash"
+          },
+          "view_id": {
+            "type": "string",
+            "description": "The id of the saved view this scope counts. The server reads that view and compiles the same\nquery the thread list runs for it, so the count and the list cannot describe the view\ndifferently.\n\nRequired for `saved_view` scopes unless `q` is supplied instead; rejected for the other two\ntypes. A `shared_inbox` scope needs no predicate field at all, because its query follows from\nthe type and its `inbox_id`. An `organization` scope uses the canonical folder queries.\n\nThe view's own shared-inbox filter is read from the stored view, so `inbox_id` need not be\nsent alongside this.\n\nCompilation is enabled per organization by the `message-unread-unified-predicate` feature\nflag. While it is off, a scope supplying only a `view_id` has no query to run and its name is\nreturned in `omitted` rather than counted. A named view that this organization does not have,\nor whose stored configuration cannot be read, is omitted the same way.\n",
+            "example": "3f34ce73-089c-4d45-a5ee-c161234e41c3"
           },
           "inbox_id": {
             "description": "Shared inbox ids, resolved to bucket ids the same way `threads:search` resolves them.",
@@ -2751,7 +2867,7 @@
               "organization",
               "user"
             ],
-            "description": "Which read state to count against — the org's or the calling user's. Same meaning as\n`getUnread`'s path parameter, and unrelated to a scope's `type`.\n"
+            "description": "Which read state to count against \u2014 the org's or the calling user's. Same meaning as\n`getUnread`'s path parameter, and unrelated to a scope's `type`.\n"
           },
           "email_filter": {
             "type": "array",
@@ -2759,6 +2875,13 @@
               "type": "string"
             },
             "description": "Restrict every scope to messages involving these addresses."
+          },
+          "user_groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The caller's group ids, as `group_<id>`, with the same meaning and constraints as on\n`threads:search`. Read only when a scope carries a `view`. Entries not matching\n`group_<id>` are dropped. Not an authorization input.\n"
           },
           "scopes": {
             "type": "array",
@@ -2791,7 +2914,7 @@
           },
           "omitted": {
             "type": "array",
-            "description": "Names of scopes that were accepted but could not be counted — today, a shared inbox whose\nids matched no bucket in this org. Listed explicitly so a caller can tell an omission apart\nfrom a mis-spelled scope name, both of which are otherwise just a missing key in `counts`.\n",
+            "description": "Names of scopes that were accepted but could not be counted. Each appears here and is\nabsent from `counts`, so an omission is distinguishable from a mis-spelled scope name.\n\nCauses, not distinguishable from this field: a `shared_inbox` scope whose ids matched no\nbucket in the organization; a scope with no query to run because compilation is disabled for\nthe organization and no `q` was supplied; and a `view_id` naming a view this organization\ndoes not have or whose stored configuration cannot be read.\n",
             "items": {
               "type": "string"
             }
@@ -2827,9 +2950,6 @@
       },
       "SearchParamsV2": {
         "type": "object",
-        "required": [
-          "q"
-        ],
         "properties": {
           "inbox_id": {
             "oneOf": [
@@ -2852,9 +2972,24 @@
             ]
           },
           "q": {
-            "description": "Lucene query syntax supported with ElasticSearch",
+            "description": "Lucene query syntax supported with ElasticSearch.\n\nSend this or `view`, not both. At least one is required; a request with neither is refused\nwith a 400. An empty string is accepted and returns no hits.\n",
             "type": "string",
             "example": "subject:\"Request for solar panel price\" AND _tags:INBOX"
+          },
+          "view": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ThreadView"
+              }
+            ],
+            "description": "A view for the server to compile into the query, instead of supplying `q`. When a view is\npresent and compilation is enabled for the calling organization, the compiled query runs and\n`q` is not consulted.\n\nRead by `threads:search` and `threads:searchIds` only. This schema is shared with\n`messages:search`, which compiles no view and ignores the field, so a request there must\nsupply `q`.\n\nCompilation is enabled per organization by the `message-unread-unified-predicate` feature\nflag. While it is off, `q` runs and a request supplying only a view returns no hits.\n"
+          },
+          "user_groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The caller's group ids, as `group_<id>`. Read only when a `view` is compiled, where they\ndetermine the agent mailbox's assignee condition and which shared inboxes, and therefore\nwhich addresses, are reachable. Required for those conditions to be correct, because group\nmembership is not present on the id token this service parses.\n\nEntries not matching `group_<id>` are dropped.\n\nNot an authorization input, and not treated as one: naming groups the caller is not in\nwidens what the response includes, exactly as supplying a broader `q` does. Access control\nis enforced elsewhere.\n"
           },
           "fields": {
             "$ref": "#/components/schemas/FieldsParam"
@@ -2913,6 +3048,21 @@
       "SearchIDParams": {
         "type": "object",
         "properties": {
+          "view": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ThreadView"
+              }
+            ],
+            "description": "The view to compile, with the same meaning as on `threads:search`. Present here because\nthis endpoint returns the ordered id set *for that list*: if one compiled its view and the\nother ran an authored `q`, the two would disagree inside a single feature, which is the\ndrift this replaces.\n"
+          },
+          "user_groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The caller's group ids, with the same meaning and caveats as on `threads:search`."
+          },
           "inbox_id": {
             "oneOf": [
               {
@@ -3160,7 +3310,7 @@
           },
           "label_name": {
             "type": "string",
-            "description": "Resolved taxonomy classification display name (e.g. `Verärgert`), when the label is a classification. Absent for free-form tags."
+            "description": "Resolved taxonomy classification display name (e.g. `Ver\u00e4rgert`), when the label is a classification. Absent for free-form tags."
           }
         }
       },
@@ -3183,7 +3333,7 @@
           },
           "label_name": {
             "type": "string",
-            "description": "Resolved taxonomy classification display name (e.g. `Verärgert`), when the label is a classification. Absent for free-form tags."
+            "description": "Resolved taxonomy classification display name (e.g. `Ver\u00e4rgert`), when the label is a classification. Absent for free-form tags."
           }
         }
       },
@@ -3400,7 +3550,7 @@
           "timestamp": {
             "type": "string",
             "description": "Timestamp of the event",
-            "example": "2024-01-01T00:00:00Z"
+            "example": "2024-01-01T00:00:00.000Z"
           },
           "message_id": {
             "type": "string",


### PR DESCRIPTION
## What

Regenerates `@epilot/message-client` so it carries the F3 additions from `svc-centralized-message-api`:

- **`ThreadView`** — a central-inbox view described structurally (folder, mailbox, labels, purposes, state filters, from/to, assignees, date range, free text) for the service to compile into a query.
- **`view`** and **`user_groups`** on `threads:search` and `threads:searchIds`.
- **`q` is now optional** on `SearchParamsV2` and `SearchIDParams` — a caller sends either predicate.
- **`view_id`** on `UnreadCountScope`, so a count scope names the saved view it counts.

`minor` changeset included; no hand-written version bump.

## Why now

F3 is deployed to dev and not yet to prod. Three shims in `epilot360-messaging` exist purely to carry these fields ahead of this release and delete themselves once it lands: a hand-declared `ThreadView`, a `& { view_id?: string }` intersection on the scope type, and a cast in `withView` covering `view`, `user_groups` and the still-required `q`. Nothing is blocked on this — the fields already travel — but the duplication cannot be removed until the types ship.

## Regenerated from dev, deliberately

```
npm run openapi -- https://docs.api.dev.epilot.io/message.yaml
```

`update-openapi.js` reads the server URL from its **default** (prod) source and applies it to the override, so `servers` correctly resolves to `https://message.sls.epilot.io` rather than the dev host.

One thing it does not handle: the dev spec's own `servers` entry survives as a second array element, since `deduplicateServers` dedupes by URL but never drops a non-default server. I removed it, so the committed artifact keeps `main`'s single-server shape instead of advertising dev infrastructure. Worth fixing in the script if generating from a non-prod source becomes routine — happy to follow up separately rather than widen this PR.

## Diff scope

Checked against `main` rather than assumed:

- **Operations:** 54 → 54, none added or removed.
- **Schemas added:** `ThreadView`.
- **Schemas changed:** `SearchParamsV2`, `SearchIDParams`, `UnreadCountScope`, `UnreadCountsPayload`, `UnreadCountsResult` — all F3 — plus `TimelineEvent`, whose `timestamp` example gains milliseconds. That last one is unrelated dev drift, cosmetic, and carries no type change.

## Verification

- `npm run typegen` regenerated `openapi.d.ts`; `SearchParamsV2.q` is now `q?`, with `view?` and `user_groups?` present.
- `npm run typescript` clean, `npm run lint` (biome) clean, `npm run build` (tsc + webpack) succeeds.