### PR TITLE
chore(blueprint-manifest-client): regen with error_code/error_data (I18N-903)

### DIFF
--- a/clients/blueprint-manifest-client/package.json
+++ b/clients/blueprint-manifest-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/blueprint-manifest-client",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "description": "Client for epilot Terraform Blueprint Manifest API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/blueprint-manifest-client/src/openapi.d.ts
+++ b/clients/blueprint-manifest-client/src/openapi.d.ts
@@ -206,6 +206,28 @@ declare namespace Components {
              */
             ignored_resource_addresses?: string[];
             installation_status?: "IN_PROGRESS" | "CANCELED" | "PARTIAL" | "SUCCESS" | "FAILED";
+            /**
+             * ID of the restore (revert) job currently holding a lock on this
+             * blueprint instance's resources, or null/absent when no revert is
+             * running. Deliberately separate from `installation_status`: installs
+             * and reverts stay decoupled, so a revert must not overwrite install
+             * health — `installation_status` keeps reflecting the actual install
+             * outcome (and drives the install badge in the Blueprints overview)
+             * for the duration of the revert.
+             *
+             */
+            active_restore_job_id?: string | null;
+            /**
+             * ISO timestamp of when the current restore lock
+             * (`active_restore_job_id`) was acquired, or null/absent when no revert
+             * is running. Written and cleared alongside `active_restore_job_id`.
+             * Lets the lock self-expire: a lock older than the staleness threshold
+             * (whose job never completed the sweep, e.g. the state machine was
+             * aborted) is treated as stale so a new revert can proceed instead of
+             * being blocked forever.
+             *
+             */
+            active_restore_started_at?: string | null; // date-time
             created_at?: string; // date-time
             updated_at?: string; // date-time
             created_by?: CallerIdentity;
@@ -1154,6 +1176,28 @@ declare namespace Components {
              */
             ignored_resource_addresses?: string[];
             installation_status?: "IN_PROGRESS" | "CANCELED" | "PARTIAL" | "SUCCESS" | "FAILED";
+            /**
+             * ID of the restore (revert) job currently holding a lock on this
+             * blueprint instance's resources, or null/absent when no revert is
+             * running. Deliberately separate from `installation_status`: installs
+             * and reverts stay decoupled, so a revert must not overwrite install
+             * health — `installation_status` keeps reflecting the actual install
+             * outcome (and drives the install badge in the Blueprints overview)
+             * for the duration of the revert.
+             *
+             */
+            active_restore_job_id?: string | null;
+            /**
+             * ISO timestamp of when the current restore lock
+             * (`active_restore_job_id`) was acquired, or null/absent when no revert
+             * is running. Written and cleared alongside `active_restore_job_id`.
+             * Lets the lock self-expire: a lock older than the staleness threshold
+             * (whose job never completed the sweep, e.g. the state machine was
+             * aborted) is treated as stale so a new revert can proceed instead of
+             * being blocked forever.
+             *
+             */
+            active_restore_started_at?: string | null; // date-time
             created_at?: string; // date-time
             updated_at?: string; // date-time
             created_by?: CallerIdentity;
@@ -1573,6 +1617,28 @@ declare namespace Components {
              */
             ignored_resource_addresses?: string[];
             installation_status?: "IN_PROGRESS" | "CANCELED" | "PARTIAL" | "SUCCESS" | "FAILED";
+            /**
+             * ID of the restore (revert) job currently holding a lock on this
+             * blueprint instance's resources, or null/absent when no revert is
+             * running. Deliberately separate from `installation_status`: installs
+             * and reverts stay decoupled, so a revert must not overwrite install
+             * health — `installation_status` keeps reflecting the actual install
+             * outcome (and drives the install badge in the Blueprints overview)
+             * for the duration of the revert.
+             *
+             */
+            active_restore_job_id?: string | null;
+            /**
+             * ISO timestamp of when the current restore lock
+             * (`active_restore_job_id`) was acquired, or null/absent when no revert
+             * is running. Written and cleared alongside `active_restore_job_id`.
+             * Lets the lock self-expire: a lock older than the staleness threshold
+             * (whose job never completed the sweep, e.g. the state machine was
+             * aborted) is treated as stale so a new revert can proceed instead of
+             * being blocked forever.
+             *
+             */
+            active_restore_started_at?: string | null; // date-time
             created_at?: string; // date-time
             updated_at?: string; // date-time
             created_by?: CallerIdentity;
@@ -1808,6 +1874,28 @@ declare namespace Components {
              */
             ignored_resource_addresses?: string[];
             installation_status?: "IN_PROGRESS" | "CANCELED" | "PARTIAL" | "SUCCESS" | "FAILED";
+            /**
+             * ID of the restore (revert) job currently holding a lock on this
+             * blueprint instance's resources, or null/absent when no revert is
+             * running. Deliberately separate from `installation_status`: installs
+             * and reverts stay decoupled, so a revert must not overwrite install
+             * health — `installation_status` keeps reflecting the actual install
+             * outcome (and drives the install badge in the Blueprints overview)
+             * for the duration of the revert.
+             *
+             */
+            active_restore_job_id?: string | null;
+            /**
+             * ISO timestamp of when the current restore lock
+             * (`active_restore_job_id`) was acquired, or null/absent when no revert
+             * is running. Written and cleared alongside `active_restore_job_id`.
+             * Lets the lock self-expire: a lock older than the staleness threshold
+             * (whose job never completed the sweep, e.g. the state machine was
+             * aborted) is treated as stale so a new revert can proceed instead of
+             * being blocked forever.
+             *
+             */
+            active_restore_started_at?: string | null; // date-time
             created_at?: string; // date-time
             updated_at?: string; // date-time
             created_by?: CallerIdentity;
@@ -2089,6 +2177,28 @@ declare namespace Components {
              */
             ignored_resource_addresses?: string[];
             installation_status?: "IN_PROGRESS" | "CANCELED" | "PARTIAL" | "SUCCESS" | "FAILED";
+            /**
+             * ID of the restore (revert) job currently holding a lock on this
+             * blueprint instance's resources, or null/absent when no revert is
+             * running. Deliberately separate from `installation_status`: installs
+             * and reverts stay decoupled, so a revert must not overwrite install
+             * health — `installation_status` keeps reflecting the actual install
+             * outcome (and drives the install badge in the Blueprints overview)
+             * for the duration of the revert.
+             *
+             */
+            active_restore_job_id?: string | null;
+            /**
+             * ISO timestamp of when the current restore lock
+             * (`active_restore_job_id`) was acquired, or null/absent when no revert
+             * is running. Written and cleared alongside `active_restore_job_id`.
+             * Lets the lock self-expire: a lock older than the staleness threshold
+             * (whose job never completed the sweep, e.g. the state machine was
+             * aborted) is treated as stale so a new revert can proceed instead of
+             * being blocked forever.
+             *
+             */
+            active_restore_started_at?: string | null; // date-time
             created_at?: string; // date-time
             updated_at?: string; // date-time
             created_by?: CallerIdentity;
@@ -3008,6 +3118,28 @@ declare namespace Components {
              */
             ignored_resource_addresses?: string[];
             installation_status?: "IN_PROGRESS" | "CANCELED" | "PARTIAL" | "SUCCESS" | "FAILED";
+            /**
+             * ID of the restore (revert) job currently holding a lock on this
+             * blueprint instance's resources, or null/absent when no revert is
+             * running. Deliberately separate from `installation_status`: installs
+             * and reverts stay decoupled, so a revert must not overwrite install
+             * health — `installation_status` keeps reflecting the actual install
+             * outcome (and drives the install badge in the Blueprints overview)
+             * for the duration of the revert.
+             *
+             */
+            active_restore_job_id?: string | null;
+            /**
+             * ISO timestamp of when the current restore lock
+             * (`active_restore_job_id`) was acquired, or null/absent when no revert
+             * is running. Written and cleared alongside `active_restore_job_id`.
+             * Lets the lock self-expire: a lock older than the staleness threshold
+             * (whose job never completed the sweep, e.g. the state machine was
+             * aborted) is treated as stale so a new revert can proceed instead of
+             * being blocked forever.
+             *
+             */
+            active_restore_started_at?: string | null; // date-time
             created_at?: string; // date-time
             updated_at?: string; // date-time
             created_by?: CallerIdentity;
@@ -3330,7 +3462,7 @@ declare namespace Components {
             /**
              * Only set when `action == skip`.
              */
-            reason?: "modified" | "delete_unsupported" | "heuristic_match" | "co_owned";
+            reason?: "modified" | "delete_unsupported" | "heuristic_match" | "co_owned" | "dependency_protected" | "already_deleted" | "non_revertible";
             /**
              * Only set when `reason == modified`. From the lineage row's last install write.
              */
@@ -3360,6 +3492,17 @@ declare namespace Components {
             co_owned_by?: {
                 blueprint_id: string;
                 title?: string | null;
+            }[];
+            /**
+             * Only set when `reason == dependency_protected`. The surviving
+             * resource(s) whose 'hard' reference to this one is why it wasn't
+             * deleted (e.g. a skipped Journey still triggering this Automation).
+             *
+             */
+            protected_by?: {
+                lineage_id: string;
+                type: string;
+                target_id?: string | null;
             }[];
         }
         export interface RootResourceNode {
@@ -3508,6 +3651,19 @@ declare namespace Components {
             status: "pending" | "in_progress" | "done" | "failed" | "skipped";
             target_id?: string;
             error_message?: string;
+            /**
+             * Stable machine code for a failed resource, when config-engine threw a
+             * typed error. Keys a translation in the Blueprints UI; `error_message`
+             * is the English fallback when absent or unrecognised.
+             *
+             */
+            error_code?: string;
+            /**
+             * Interpolation values for the translated `error_code` message.
+             */
+            error_data?: {
+                [name: string]: any;
+            };
         }
         export interface VerificationSummary {
             total_resources?: number;
@@ -6098,8 +6254,14 @@ export interface OperationMethods {
    * snapshot ids directly.
    * 
    * Async — returns 202 with a job id. Poll the job to track progress.
-   * The per-instance lock (`installation_status === 'IN_PROGRESS'`)
-   * rejects concurrent installs or restores with 409.
+   * The restore holds its own per-instance lock (`active_restore_job_id`),
+   * separate from `installation_status`. Starting a restore is rejected with
+   * 409 when another restore already holds that lock, or when an install is
+   * running (`installation_status === 'IN_PROGRESS'`). Keeping the two locks
+   * distinct keeps installs and reverts decoupled: an in-flight or failed
+   * restore never overwrites `installation_status`, which keeps reflecting
+   * the actual install outcome (and drives the install badge in the
+   * Blueprints overview) throughout the revert.
    * 
    */
   'restoreBlueprintDeploymentV3'(
@@ -7059,8 +7221,14 @@ export interface PathsDictionary {
      * snapshot ids directly.
      * 
      * Async — returns 202 with a job id. Poll the job to track progress.
-     * The per-instance lock (`installation_status === 'IN_PROGRESS'`)
-     * rejects concurrent installs or restores with 409.
+     * The restore holds its own per-instance lock (`active_restore_job_id`),
+     * separate from `installation_status`. Starting a restore is rejected with
+     * 409 when another restore already holds that lock, or when an install is
+     * running (`installation_status === 'IN_PROGRESS'`). Keeping the two locks
+     * distinct keeps installs and reverts decoupled: an in-flight or failed
+     * restore never overwrites `installation_status`, which keeps reflecting
+     * the actual install outcome (and drives the install badge in the
+     * Blueprints overview) throughout the revert.
      * 
      */
     'post'(

--- a/clients/blueprint-manifest-client/src/openapi.json
+++ b/clients/blueprint-manifest-client/src/openapi.json
@@ -3429,7 +3429,7 @@
       "post": {
         "operationId": "restoreBlueprintDeploymentV3",
         "summary": "restoreBlueprintDeploymentV3",
-        "description": "Roll a deployment back to its pre-install state. Two phases:\n\n  1. Upsert — re-applies the captured payloads via snapshot-api's\n     `:restore` (server-side; runs config-engine.apply with captured\n     target ids pre-seeded). Skipped for pure-create deployments\n     whose snapshot was empty.\n  2. Delete sweep — for lineage rows of this blueprint instance not\n     present in the snapshot's captured set, deletes the live\n     resource via the type's adapter. Co-ownership / drift /\n     no-delete-capability skip the entry with the corresponding\n     reason.\n\nResolves `(blueprint_id, job_id)` to the entry in\n`Blueprint.deployments[]` and reads its `snapshot_id` and\n`destination_blueprint_id` — the caller never needs to handle\nsnapshot ids directly.\n\nAsync — returns 202 with a job id. Poll the job to track progress.\nThe per-instance lock (`installation_status === 'IN_PROGRESS'`)\nrejects concurrent installs or restores with 409.\n",
+        "description": "Roll a deployment back to its pre-install state. Two phases:\n\n  1. Upsert — re-applies the captured payloads via snapshot-api's\n     `:restore` (server-side; runs config-engine.apply with captured\n     target ids pre-seeded). Skipped for pure-create deployments\n     whose snapshot was empty.\n  2. Delete sweep — for lineage rows of this blueprint instance not\n     present in the snapshot's captured set, deletes the live\n     resource via the type's adapter. Co-ownership / drift /\n     no-delete-capability skip the entry with the corresponding\n     reason.\n\nResolves `(blueprint_id, job_id)` to the entry in\n`Blueprint.deployments[]` and reads its `snapshot_id` and\n`destination_blueprint_id` — the caller never needs to handle\nsnapshot ids directly.\n\nAsync — returns 202 with a job id. Poll the job to track progress.\nThe restore holds its own per-instance lock (`active_restore_job_id`),\nseparate from `installation_status`. Starting a restore is rejected with\n409 when another restore already holds that lock, or when an install is\nrunning (`installation_status === 'IN_PROGRESS'`). Keeping the two locks\ndistinct keeps installs and reverts decoupled: an in-flight or failed\nrestore never overwrites `installation_status`, which keeps reflecting\nthe actual install outcome (and drives the install badge in the\nBlueprints overview) throughout the revert.\n",
         "tags": [
           "Blueprints"
         ],
@@ -4592,6 +4592,17 @@
               "FAILED"
             ]
           },
+          "active_restore_job_id": {
+            "type": "string",
+            "nullable": true,
+            "description": "ID of the restore (revert) job currently holding a lock on this\nblueprint instance's resources, or null/absent when no revert is\nrunning. Deliberately separate from `installation_status`: installs\nand reverts stay decoupled, so a revert must not overwrite install\nhealth — `installation_status` keeps reflecting the actual install\noutcome (and drives the install badge in the Blueprints overview)\nfor the duration of the revert.\n"
+          },
+          "active_restore_started_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "ISO timestamp of when the current restore lock\n(`active_restore_job_id`) was acquired, or null/absent when no revert\nis running. Written and cleared alongside `active_restore_job_id`.\nLets the lock self-expire: a lock older than the staleness threshold\n(whose job never completed the sweep, e.g. the state machine was\naborted) is treated as stale so a new revert can proceed instead of\nbeing blocked forever.\n"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"
@@ -5567,6 +5578,15 @@
           },
           "error_message": {
             "type": "string"
+          },
+          "error_code": {
+            "type": "string",
+            "description": "Stable machine code for a failed resource, when config-engine threw a\ntyped error. Keys a translation in the Blueprints UI; `error_message`\nis the English fallback when absent or unrecognised.\n"
+          },
+          "error_data": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Interpolation values for the translated `error_code` message."
           }
         }
       },
@@ -5610,7 +5630,10 @@
               "modified",
               "delete_unsupported",
               "heuristic_match",
-              "co_owned"
+              "co_owned",
+              "dependency_protected",
+              "already_deleted",
+              "non_revertible"
             ]
           },
           "last_synced_at": {
@@ -5647,6 +5670,29 @@
                   "type": "string"
                 },
                 "title": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          },
+          "protected_by": {
+            "type": "array",
+            "description": "Only set when `reason == dependency_protected`. The surviving\nresource(s) whose 'hard' reference to this one is why it wasn't\ndeleted (e.g. a skipped Journey still triggering this Automation).\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "lineage_id",
+                "type"
+              ],
+              "properties": {
+                "lineage_id": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "target_id": {
                   "type": "string",
                   "nullable": true
                 }


### PR DESCRIPTION
## Summary

Regenerates `@epilot/blueprint-manifest-client` from the merged `blueprint-manifest-api` OpenAPI so `V3ResourceProgressEntry` carries the new **`error_code`** + **`error_data`** fields — the SDK half of the I18N-903 chain that makes config-engine V3 apply failures translatable end-to-end.

- **5.4.0 → 5.5.0** (minor: additive optional response fields, backward-compatible).
- Regenerated from the merged bm-api spec (prod mirror `docs.api.epilot.io` hadn't picked up the deploy yet — used the "still deploying" local-spec shortcut from CONTRIBUTING).
- Regen also pulls in **restore-progress schema the 5.4.0 client had drifted behind** (`active_restore_job_id`, `active_restore_started_at`, `protected_by`, revert `reason` enum) — legitimate already-merged API fields, not part of I18N-903, surfaced because the client was stale.

## Downstream

`epilot360-blueprints` (!454) bumps its pin `"@epilot/blueprint-manifest-client": "5.4.0" → "5.5.0"` so `LiveResourceStatus.svelte` can read `resource.error_code`/`error_data` and render `i18n.t(\`errors.${code}\`, error_message, error_data)`.

## Test plan
- [x] `npm run typegen && npm run build` — clean
- [x] `npm run lint` (biome) — clean
- [x] `npm test` — 3/3 pass
- [x] diff scoped: only `error_code`/`error_data` + restore drift; no server-URL change

🤖 Generated with [Claude Code](https://claude.com/claude-code)