### PR TITLE
chore(permissions-client): regen with not_equals grant conditions

### DIFF
--- a/clients/permissions-client/package.json
+++ b/clients/permissions-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/permissions-client",
-  "version": "0.16.6",
+  "version": "0.17.0",
   "description": "Client library for epilot Permissions API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/permissions-client/src/openapi.d.ts
+++ b/clients/permissions-client/src/openapi.d.ts
@@ -346,10 +346,13 @@ declare namespace Components {
              */
             attribute: string;
             operation: "equals";
-            values: any[];
+            values: [
+                any,
+                ...any[]
+            ];
         }
         /**
-         * Check if any relation_user attribute on the entity contains the current user. When attribute is provided, only that specific attribute path is checked.
+         * Check if any relation_user attribute on the entity contains the current user. When attribute is provided, only that specific attribute path is checked. When attributes is provided, it takes precedence over attribute and the condition passes when the current user appears in ANY of the listed attribute paths.
          */
         export interface EqualsCurrentUserCondition {
             /**
@@ -358,6 +361,18 @@ declare namespace Components {
              * assignee.*.user_id
              */
             attribute?: string;
+            /**
+             * Optional list of JSON paths to user attributes. Takes precedence over attribute.
+             * example:
+             * [
+             *   "assignee.*.user_id",
+             *   "owner.*.user_id"
+             * ]
+             */
+            attributes?: [
+                string,
+                ...string[]
+            ];
             operation: "equals_current_user";
         }
         /**
@@ -388,7 +403,7 @@ declare namespace Components {
         /**
          * An additional condition that must be met for the grant
          */
-        export type GrantCondition = /* An additional condition that must be met for the grant */ /* Check if attribute equals to any of the values */ EqualsCondition | /* Check if any relation_user attribute on the entity contains the current user. When attribute is provided, only that specific attribute path is checked. */ EqualsCurrentUserCondition;
+        export type GrantCondition = /* An additional condition that must be met for the grant */ /* Check if attribute equals to any of the values */ EqualsCondition | /* Passes when the attribute does not equal any of the values. Records where the attribute is missing or empty pass the condition. */ NotEqualsCondition | /* Check if any relation_user attribute on the entity contains the current user. When attribute is provided, only that specific attribute path is checked. When attributes is provided, it takes precedence over attribute and the condition passes when the current user appears in ANY of the listed attribute paths. */ EqualsCurrentUserCondition | /* Check if the current user is absent from the relation_user attributes on the entity. When attribute is provided, only that specific attribute path is checked. When attributes is provided, it takes precedence over attribute and the condition passes only when the current user appears in NONE of the listed attribute paths. */ NotEqualsCurrentUserCondition;
         export interface GrantWithDependencies {
             /**
              * example:
@@ -423,6 +438,45 @@ declare namespace Components {
              * 123:owner
              */
             RoleId[];
+        }
+        /**
+         * Passes when the attribute does not equal any of the values. Records where the attribute is missing or empty pass the condition.
+         */
+        export interface NotEqualsCondition {
+            /**
+             * example:
+             * workflows.primary.task_name
+             */
+            attribute: string;
+            operation: "not_equals";
+            values: [
+                any,
+                ...any[]
+            ];
+        }
+        /**
+         * Check if the current user is absent from the relation_user attributes on the entity. When attribute is provided, only that specific attribute path is checked. When attributes is provided, it takes precedence over attribute and the condition passes only when the current user appears in NONE of the listed attribute paths.
+         */
+        export interface NotEqualsCurrentUserCondition {
+            /**
+             * Optional JSON path to a specific user attribute. When omitted, all relation_user attributes on the entity are scanned.
+             * example:
+             * assignee.*.user_id
+             */
+            attribute?: string;
+            /**
+             * Optional list of JSON paths to user attributes. Takes precedence over attribute.
+             * example:
+             * [
+             *   "assignee.*.user_id",
+             *   "owner.*.user_id"
+             * ]
+             */
+            attributes?: [
+                string,
+                ...string[]
+            ];
+            operation: "not_equals_current_user";
         }
         /**
          * All roles attached to an users of an organization
@@ -962,6 +1016,7 @@ declare namespace Paths {
     }
 }
 
+
 export interface OperationMethods {
   /**
    * listCurrentRoles - listCurrentRoles
@@ -1252,6 +1307,7 @@ export interface PathsDictionary {
 
 export type Client = OpenAPIClient<OperationMethods, PathsDictionary>
 
+
 export type Assignment = Components.Schemas.Assignment;
 export type Assignments = Components.Schemas.Assignments;
 export type BaseRole = Components.Schemas.BaseRole;
@@ -1264,6 +1320,8 @@ export type Grant = Components.Schemas.Grant;
 export type GrantCondition = Components.Schemas.GrantCondition;
 export type GrantWithDependencies = Components.Schemas.GrantWithDependencies;
 export type InternalAssignment = Components.Schemas.InternalAssignment;
+export type NotEqualsCondition = Components.Schemas.NotEqualsCondition;
+export type NotEqualsCurrentUserCondition = Components.Schemas.NotEqualsCurrentUserCondition;
 export type OrgAssignments = Components.Schemas.OrgAssignments;
 export type OrgRole = Components.Schemas.OrgRole;
 export type OrgRoles = Components.Schemas.OrgRoles;

--- a/clients/permissions-client/src/openapi.json
+++ b/clients/permissions-client/src/openapi.json
@@ -929,14 +929,20 @@
                 "$ref": "#/components/schemas/EqualsCondition"
               },
               {
+                "$ref": "#/components/schemas/NotEqualsCondition"
+              },
+              {
                 "$ref": "#/components/schemas/EqualsCurrentUserCondition"
+              },
+              {
+                "$ref": "#/components/schemas/NotEqualsCurrentUserCondition"
               }
             ]
           }
         ]
       },
       "EqualsCurrentUserCondition": {
-        "description": "Check if any relation_user attribute on the entity contains the current user. When attribute is provided, only that specific attribute path is checked.",
+        "description": "Check if any relation_user attribute on the entity contains the current user. When attribute is provided, only that specific attribute path is checked. When attributes is provided, it takes precedence over attribute and the condition passes when the current user appears in ANY of the listed attribute paths.",
         "type": "object",
         "properties": {
           "attribute": {
@@ -944,10 +950,54 @@
             "description": "Optional JSON path to a specific user attribute. When omitted, all relation_user attributes on the entity are scanned.",
             "example": "assignee.*.user_id"
           },
+          "attributes": {
+            "type": "array",
+            "description": "Optional list of JSON paths to user attributes. Takes precedence over attribute.",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "assignee.*.user_id",
+              "owner.*.user_id"
+            ]
+          },
           "operation": {
             "type": "string",
             "enum": [
               "equals_current_user"
+            ]
+          }
+        },
+        "required": [
+          "operation"
+        ]
+      },
+      "NotEqualsCurrentUserCondition": {
+        "description": "Check if the current user is absent from the relation_user attributes on the entity. When attribute is provided, only that specific attribute path is checked. When attributes is provided, it takes precedence over attribute and the condition passes only when the current user appears in NONE of the listed attribute paths.",
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "description": "Optional JSON path to a specific user attribute. When omitted, all relation_user attributes on the entity are scanned.",
+            "example": "assignee.*.user_id"
+          },
+          "attributes": {
+            "type": "array",
+            "description": "Optional list of JSON paths to user attributes. Takes precedence over attribute.",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "assignee.*.user_id",
+              "owner.*.user_id"
+            ]
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "not_equals_current_user"
             ]
           }
         },
@@ -971,6 +1021,35 @@
           },
           "values": {
             "type": "array",
+            "minItems": 1,
+            "items": {
+              "example": "Qualification"
+            }
+          }
+        },
+        "required": [
+          "attribute",
+          "operation",
+          "values"
+        ]
+      },
+      "NotEqualsCondition": {
+        "description": "Passes when the attribute does not equal any of the values. Records where the attribute is missing or empty pass the condition.",
+        "type": "object",
+        "properties": {
+          "attribute": {
+            "type": "string",
+            "example": "workflows.primary.task_name"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "not_equals"
+            ]
+          },
+          "values": {
+            "type": "array",
+            "minItems": 1,
             "items": {
               "example": "Qualification"
             }
@@ -1511,5 +1590,9 @@
       }
     }
   },
-  "servers": []
+  "servers": [
+    {
+      "url": "https://permissions.sls.epilot.io"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Regenerate `@epilot/permissions-client` from the permissions-api spec ([`0971abf`](https://gitlab.com/e-pilot/product/permissions-api) — *feat(permissions): not_equals operators, multi-attribute current-user conditions*) so `GrantCondition` covers the new operators:

- `NotEqualsCondition` — `operation: not_equals`. Passes when the attribute does not equal any of the values; records where the attribute is missing or empty pass.
- `NotEqualsCurrentUserCondition` — `operation: not_equals_current_user`.
- `attributes[]` on both current-user conditions — a list of JSON paths that takes precedence over the single `attribute`.

Bump `0.16.6` -> `0.17.0`.

## Notes

- Mostly additive, with one type tightening: `values` picks up `minItems: 1` from the spec and is now `[any, ...any[]]` instead of `any[]`, so a consumer passing a plain `string[]` variable will need a non-empty tuple. Went minor rather than major on a `0.x` client.
- `info.version` in the permissions-api spec is still `1.2.1` — not bumped upstream despite the new schemas.
- `@epilot/permissions-client` is not published by CI (`auto-release` only covers `@epilot/sdk` and `@epilot/cli`), so `0.17.0` needs a manual `npm publish` after merge.

## Test plan

- [x] `npm run openapi <local spec>` + `npm run typegen` + `npm run build`
- [x] `npm run lint` clean
- [x] `npx vitest run` — 3 tests pass