### PR TITLE
chore(validation-rules-client): bump to 1.4.1 for a clean republish

### DIFF
--- a/clients/validation-rules-client/package.json
+++ b/clients/validation-rules-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/validation-rules-client",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "API Client for epilot Validation Rules API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Problem

The published `@epilot/validation-rules-client@1.4.0` tarball is missing `dist/openapi.d.ts`:

```
$ npm pack @epilot/validation-rules-client@1.3.0 && tar tzf …
package/dist/index.d.ts
package/dist/index.js
package/dist/openapi.d.ts     ← present

$ npm pack @epilot/validation-rules-client@1.4.0 && tar tzf …
package/dist/index.d.ts
package/dist/index.js         ← openapi.d.ts missing
```

`dist/index.d.ts` does `export * from './openapi'`, so with that file absent the re-export dangles and **every TypeScript consumer of 1.4.0 gets no types** — `Components`, `ValidationRule` and friends are unresolvable:

```
error TS2305: Module '"@epilot/validation-rules-client"' has no exported member 'Components'.
```

## Cause

Not a build bug — the build is correct. `bundle-definition` (webpack) copies the file:

```
asset openapi.d.ts 53.9 KiB [emitted] [from: src/openapi.d.ts] [copied]
```

and `npm pack --dry-run` after a clean `pnpm run build` lists `dist/openapi.d.ts` (55.2 kB). `build:patch` deliberately strips the runtime `require` of `./openapi` from `index.js`, confirming the file is types-only and expected in `dist`.

So 1.4.0 went out without that build having run (published from an empty or stale `dist`).

## Fix

No source change — npm won't allow overwriting a published version, so this is a patch bump to republish cleanly. **When publishing, make sure the build runs** (`prepublishOnly` does `typegen && build`) so `dist/openapi.d.ts` is in the tarball. Worth a `tar tzf` sanity check on the packed artifact before pushing it.

## Follow-on

The two consumer MRs currently pin `1.4.0` and will be re-pinned to `1.4.1` once it is published:

- [validation-rules-engine!10](https://gitlab.com/e-pilot/product/validation-rules/validation-rules-engine/-/merge_requests/10)
- [epilot360-validation-rules!48](https://gitlab.com/e-pilot/product/360-portal/epilot360-validation-rules/-/merge_requests/48)

## Test plan

- [x] Clean `pnpm run build` emits `dist/openapi.d.ts`
- [x] `npm pack --dry-run` includes it (10 files total)
- [x] Confirmed 1.3.0 shipped it and 1.4.0 does not
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uw2rkr9Fz4wrHZgGmgrDdv)_