### PR TITLE
chore(billing-client): add installment pricing snapshot

### DIFF
--- a/clients/billing-client/package.json
+++ b/clients/billing-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/billing-client",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "API Client for epilot Billing API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/billing-client/src/openapi.d.ts
+++ b/clients/billing-client/src/openapi.d.ts
@@ -1284,6 +1284,31 @@ declare namespace Components {
                 tariffs?: ContractTariffContext[];
             } | null;
             changed_fields: ("tariff" | "base_price" | "working_price" | "discount" | "dynamic_tariff_configuration")[];
+            /**
+             * Installment amount effective when the pricing change was recorded.
+             */
+            installment_amount?: {
+                /**
+                 * Amount in cents when available or derivable.
+                 * example:
+                 * 10050
+                 */
+                amount?: number;
+                /**
+                 * Decimal amount string when available or derivable.
+                 * example:
+                 * 100.50
+                 */
+                amount_decimal?: string;
+                currency?: /**
+                 * Currency code in ISO 4217 format (Währungscode).
+                 * Common values: EUR (Euro), CHF (Swiss Franc)
+                 *
+                 * example:
+                 * EUR
+                 */
+                Currency;
+            };
         }
         export interface ContractPricingContext {
             base_price?: PriceContext;

--- a/clients/billing-client/src/openapi.json
+++ b/clients/billing-client/src/openapi.json
@@ -2192,6 +2192,14 @@
                     "dynamic_tariff_configuration"
                   ]
                 }
+              },
+              "installment_amount": {
+                "description": "Installment amount effective when the pricing change was recorded.",
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/InstallmentAmountValue"
+                  }
+                ]
               }
             }
           }


### PR DESCRIPTION
## Summary
- expose the installment amount captured alongside contract pricing history rows
- regenerate the Billing API client types from the deployed API schema
- bump `@epilot/billing-client` from `0.7.0` to `0.7.1`

## Validation
- [x] `npm run openapi <billing-api-openapi.yml>`
- [x] `npm run typegen`
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test -- --run` (2 tests)

## Release
The Billing API schema is already deployed to production. After merging, publish `@epilot/billing-client@0.7.1`; the repository CI will also regenerate and release `@epilot/sdk`.

🤖 Generated with GPT-5.6