### PR TITLE
feat(sdk): publish runtime values from a client's schema-model.ts

### DIFF
--- a/.changeset/sdk-runtime-schema-models.md
+++ b/.changeset/sdk-runtime-schema-models.md
@@ -1,0 +1,14 @@
+---
+"@epilot/pricing-client": minor
+"@epilot/sdk": minor
+---
+
+Publish runtime values through the SDK via a client's `schema-model.ts`
+
+The SDK could only ever re-export *types* from a client's hand-written modules: `additional-types.ts` is copied to a `.d.ts` and re-exported with `export type *`, so a `const` or `enum` placed there type-checks and is then `undefined` at runtime. A client's `schema-model.ts` is now copied as a real `.ts` to `src/models/<api>-model.ts` and re-exported with `export *`, so the values survive.
+
+This fixes an existing gap: `RelationAffinityMode` has always been exported from `@epilot/entity-client` but was unreachable through `@epilot/sdk/entity` — the generator never looked at `schema-model.ts`. It is now available from both.
+
+`@epilot/pricing-client` gains a `schema-model.ts` with runtime companions for four spec enums — `PricingModelValues`, `MarkupPricingModelValues`, `TypeGetAgValues` and `DynamicTariffModeValues` — for consumers that need the values themselves (an `Object.values()` allowlist, a lookup, a `switch` default) rather than just the union type. Each is tied to its generated union with `satisfies`, so dropping a member from the spec is a compile error and the two cannot drift.
+
+A name exported from `schema-model.ts` must not also be a `components.schemas` entry, since both are re-exported from the same API entry file; hence the `<SpecType>Values` naming. See CONTRIBUTING.md.

--- a/.changeset/sdk-runtime-schema-models.md
+++ b/.changeset/sdk-runtime-schema-models.md
@@ -9,4 +9,4 @@ Only types could reach SDK consumers before — `additional-types.ts` lands in a
 
 This makes `RelationAffinityMode` reachable through `@epilot/sdk/entity` for the first time; it was already exported from `@epilot/entity-client`.
 
-`@epilot/pricing-client` gains `PricingModelValues`, `MarkupPricingModelValues`, `TypeGetAgValues` and `DynamicTariffModeValues` — the enum values themselves, for lookups and `Object.values()` allowlists, rather than just the union types. Each is tied to its spec union with `satisfies`, so the two cannot drift.
+`@epilot/pricing-client` gains `PricingModelValues`, `MarkupPricingModelValues`, `TypeGetAgValues` and `DynamicTariffModeValues` — the enum values themselves, for lookups and `Object.values()` allowlists, rather than just the union types. Each is tied to its spec union with `satisfies`, and checked against `components.schemas.<SpecType>.enum`, so a member added to or removed from the spec fails the build rather than drifting silently.

--- a/.changeset/sdk-runtime-schema-models.md
+++ b/.changeset/sdk-runtime-schema-models.md
@@ -5,10 +5,8 @@
 
 Publish runtime values through the SDK via a client's `schema-model.ts`
 
-The SDK could only ever re-export *types* from a client's hand-written modules: `additional-types.ts` is copied to a `.d.ts` and re-exported with `export type *`, so a `const` or `enum` placed there type-checks and is then `undefined` at runtime. A client's `schema-model.ts` is now copied as a real `.ts` to `src/models/<api>-model.ts` and re-exported with `export *`, so the values survive.
+Only types could reach SDK consumers before — `additional-types.ts` lands in a `.d.ts`, so a `const` or `enum` there is `undefined` at runtime. A client's `schema-model.ts` is now copied as a real `.ts` and re-exported with `export *`.
 
-This fixes an existing gap: `RelationAffinityMode` has always been exported from `@epilot/entity-client` but was unreachable through `@epilot/sdk/entity` — the generator never looked at `schema-model.ts`. It is now available from both.
+This makes `RelationAffinityMode` reachable through `@epilot/sdk/entity` for the first time; it was already exported from `@epilot/entity-client`.
 
-`@epilot/pricing-client` gains a `schema-model.ts` with runtime companions for four spec enums — `PricingModelValues`, `MarkupPricingModelValues`, `TypeGetAgValues` and `DynamicTariffModeValues` — for consumers that need the values themselves (an `Object.values()` allowlist, a lookup, a `switch` default) rather than just the union type. Each is tied to its generated union with `satisfies`, so dropping a member from the spec is a compile error and the two cannot drift.
-
-A name exported from `schema-model.ts` must not also be a `components.schemas` entry, since both are re-exported from the same API entry file; hence the `<SpecType>Values` naming. See CONTRIBUTING.md.
+`@epilot/pricing-client` gains `PricingModelValues`, `MarkupPricingModelValues`, `TypeGetAgValues` and `DynamicTariffModeValues` — the enum values themselves, for lookups and `Object.values()` allowlists, rather than just the union types. Each is tied to its spec union with `satisfies`, so the two cannot drift.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,44 +27,33 @@ npm version patch --no-git-tag-version
 git commit -am 'chore(entity-client): update client with new spec'
 ```
 
-## Hand-written modules in a client (`additional-types.ts` / `schema-model.ts`)
+## Hand-written modules in a client
 
-Almost everything a client exposes is generated from `openapi.json`. Two files are
-hand-written, and the SDK generator treats them differently — pick by whether the
-thing you are adding has to exist at **runtime**.
+Two files in a client are not generated from `openapi.json`. Pick by whether what
+you are adding has to exist at **runtime**:
 
 | File | Holds | Copied to | Re-exported as |
 | --- | --- | --- | --- |
 | `src/additional-types.ts` | types only | `src/types/<api>-additional.d.ts` | `export type *` |
-| `src/schema-model.ts` | runtime values (enums, frozen constants) | `src/models/<api>-model.ts` | `export *` |
+| `src/schema-model.ts` | runtime values | `src/models/<api>-model.ts` | `export *` |
 
-A `const` or `enum` put in `additional-types.ts` will type-check and then be
-`undefined` for every `@epilot/sdk/<api>` consumer, because it is copied into a
-`.d.ts` and re-exported with `export type *`. Runtime values belong in
-`schema-model.ts`.
+A `const` or `enum` in `additional-types.ts` type-checks and is then `undefined`
+for SDK consumers, because it lands in a `.d.ts`. Values belong in `schema-model.ts`,
+under two rules:
 
-Two rules for `schema-model.ts`:
-
-- **Do not reuse a `components.schemas` name.** Both modules are re-exported from
-  the same API entry file, so a clash is a build error. Name the runtime companion
-  of a spec type `<SpecType>Values` — e.g. the spec's `PricingModel` union is
-  accompanied by `PricingModelValues`.
-- **Tie the values back to the spec with `satisfies`**, so the copy cannot drift:
+- **Don't reuse a `components.schemas` name.** Both files are re-exported from the
+  same API entry file, so a clash breaks the build. Name a spec type's runtime
+  companion `<SpecType>Values`.
+- **Tie the values to the spec with `satisfies`**, so they can't drift:
 
   ```ts
-  import type { PricingModel } from './openapi'
-
   export const PricingModelValues = {
     perUnit: 'per_unit',
-    // ...
   } as const satisfies Record<string, PricingModel>
   ```
 
-  Remove a member from the spec and this stops compiling, which is the point —
-  it is the only thing keeping a hand-maintained list honest.
-
-After adding or editing either file, run `pnpm generate` in `packages/epilot-sdk-v2`
-and commit the regenerated output.
+After editing either, run `pnpm generate` in `packages/epilot-sdk-v2` and commit
+the regenerated output.
 
 ## Auto-release (`@epilot/sdk`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,45 @@ npm version patch --no-git-tag-version
 git commit -am 'chore(entity-client): update client with new spec'
 ```
 
+## Hand-written modules in a client (`additional-types.ts` / `schema-model.ts`)
+
+Almost everything a client exposes is generated from `openapi.json`. Two files are
+hand-written, and the SDK generator treats them differently — pick by whether the
+thing you are adding has to exist at **runtime**.
+
+| File | Holds | Copied to | Re-exported as |
+| --- | --- | --- | --- |
+| `src/additional-types.ts` | types only | `src/types/<api>-additional.d.ts` | `export type *` |
+| `src/schema-model.ts` | runtime values (enums, frozen constants) | `src/models/<api>-model.ts` | `export *` |
+
+A `const` or `enum` put in `additional-types.ts` will type-check and then be
+`undefined` for every `@epilot/sdk/<api>` consumer, because it is copied into a
+`.d.ts` and re-exported with `export type *`. Runtime values belong in
+`schema-model.ts`.
+
+Two rules for `schema-model.ts`:
+
+- **Do not reuse a `components.schemas` name.** Both modules are re-exported from
+  the same API entry file, so a clash is a build error. Name the runtime companion
+  of a spec type `<SpecType>Values` — e.g. the spec's `PricingModel` union is
+  accompanied by `PricingModelValues`.
+- **Tie the values back to the spec with `satisfies`**, so the copy cannot drift:
+
+  ```ts
+  import type { PricingModel } from './openapi'
+
+  export const PricingModelValues = {
+    perUnit: 'per_unit',
+    // ...
+  } as const satisfies Record<string, PricingModel>
+  ```
+
+  Remove a member from the spec and this stops compiling, which is the point —
+  it is the only thing keeping a hand-maintained list honest.
+
+After adding or editing either file, run `pnpm generate` in `packages/epilot-sdk-v2`
+and commit the regenerated output.
+
 ## Auto-release (`@epilot/sdk`)
 
 When changes to any `clients/*/openapi.json` file land on `main`, the CI automatically:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,9 @@ under two rules:
 - **Don't reuse a `components.schemas` name.** Both files are re-exported from the
   same API entry file, so a clash breaks the build. Name a spec type's runtime
   companion `<SpecType>Values`.
-- **Tie the values to the spec with `satisfies`**, so they can't drift:
+- **Tie the values to the spec with `satisfies`.** The `Values` suffix is what lets
+  the SDK test match a map against `components.schemas.<SpecType>.enum`, so a member
+  added to or removed from the spec fails the build rather than drifting silently:
 
   ```ts
   export const PricingModelValues = {

--- a/clients/entity-client/src/schema-model.ts
+++ b/clients/entity-client/src/schema-model.ts
@@ -1,8 +1,6 @@
 export enum RelationAffinityMode {
-  /**
-   * For strong affinity mode on a relation attribute, deleting or creating the parent or the relation linkage will trigger a CASCADE delete or create to the relation entity itself.
-   * For weak affinity mode on a relation attribute, deleting or creating the parent or the relation linkage will NOT trigger a CASCADE delete or create to the relation entity itself.
-   */
+  /** Deleting or creating the parent or the linkage does NOT cascade to the relation entity. */
   WEAK = 'weak',
+  /** Deleting or creating the parent or the linkage cascades to the relation entity. */
   STRONG = 'strong',
 }

--- a/clients/pricing-client/package.json
+++ b/clients/pricing-client/package.json
@@ -68,7 +68,7 @@
     "openapicmd": "^2.9.2",
     "ts-loader": "^8.0.14",
     "ts-node": "^10.9.1",
-    "typescript": "^4.1.3",
+    "typescript": "^4.9.3",
     "webpack": "^5.18.0",
     "webpack-cli": "^4.4.0"
   },

--- a/clients/pricing-client/src/index.ts
+++ b/clients/pricing-client/src/index.ts
@@ -3,3 +3,4 @@ export type { OpenAPIClient, OpenAPIClientAxios, Document } from 'openapi-client
 export * from './client';
 export * from './openapi';
 export * from './additional-types';
+export * from './schema-model';

--- a/clients/pricing-client/src/schema-model.ts
+++ b/clients/pricing-client/src/schema-model.ts
@@ -2,11 +2,12 @@ import type { DynamicTariffMode, MarkupPricingModel, PricingModel, TypeGetAg } f
 
 /**
  * Runtime companions for spec enums, for consumers that need the values and not
- * just the union type — `@epilot/pricing` re-declares these in
- * `src/prices/constants.ts` today.
+ * just the union type.
  *
- * Suffixed `Values` because the spec type owns the bare name. `satisfies` stops
- * them drifting: drop a member from the spec and this no longer compiles.
+ * Suffixed `Values` because the spec type owns the bare name. That suffix is also
+ * the contract: `packages/epilot-sdk-v2/__tests__/models.test.ts` checks every
+ * `<SpecType>Values` map against `components.schemas.<SpecType>.enum`, so a member
+ * added to or removed from the spec fails the build rather than drifting silently.
  */
 
 export const PricingModelValues = {

--- a/clients/pricing-client/src/schema-model.ts
+++ b/clients/pricing-client/src/schema-model.ts
@@ -1,0 +1,41 @@
+import type { DynamicTariffMode, MarkupPricingModel, PricingModel, TypeGetAg } from './openapi';
+
+/**
+ * Runtime companions for spec enums.
+ *
+ * `components.schemas` enums generate a TypeScript union — a type, erased at
+ * runtime. Consumers that need the values themselves (a lookup, a `switch`
+ * default, an `Object.values()` allowlist) otherwise re-declare them by hand;
+ * `@epilot/pricing` carries exactly such a copy in `src/prices/constants.ts`.
+ *
+ * Named `<SpecType>Values` because the spec type already owns the bare name —
+ * exporting both from `@epilot/sdk/pricing` would collide.
+ *
+ * `satisfies` is what makes these safe to depend on: drop a member from the spec
+ * and this file stops compiling, so the two cannot drift apart silently.
+ */
+
+export const PricingModelValues = {
+  perUnit: 'per_unit',
+  tieredGraduated: 'tiered_graduated',
+  tieredVolume: 'tiered_volume',
+  tieredFlatFee: 'tiered_flatfee',
+  dynamicTariff: 'dynamic_tariff',
+  externalGetAG: 'external_getag',
+} as const satisfies Record<string, PricingModel>;
+
+export const MarkupPricingModelValues = {
+  perUnit: 'per_unit',
+  tieredVolume: 'tiered_volume',
+  tieredFlatFee: 'tiered_flatfee',
+} as const satisfies Record<string, MarkupPricingModel>;
+
+export const TypeGetAgValues = {
+  basePrice: 'base_price',
+  workPrice: 'work_price',
+} as const satisfies Record<string, TypeGetAg>;
+
+export const DynamicTariffModeValues = {
+  dayAheadMarket: 'day_ahead_market',
+  manual: 'manual',
+} as const satisfies Record<string, DynamicTariffMode>;

--- a/clients/pricing-client/src/schema-model.ts
+++ b/clients/pricing-client/src/schema-model.ts
@@ -1,18 +1,12 @@
 import type { DynamicTariffMode, MarkupPricingModel, PricingModel, TypeGetAg } from './openapi';
 
 /**
- * Runtime companions for spec enums.
+ * Runtime companions for spec enums, for consumers that need the values and not
+ * just the union type — `@epilot/pricing` re-declares these in
+ * `src/prices/constants.ts` today.
  *
- * `components.schemas` enums generate a TypeScript union — a type, erased at
- * runtime. Consumers that need the values themselves (a lookup, a `switch`
- * default, an `Object.values()` allowlist) otherwise re-declare them by hand;
- * `@epilot/pricing` carries exactly such a copy in `src/prices/constants.ts`.
- *
- * Named `<SpecType>Values` because the spec type already owns the bare name —
- * exporting both from `@epilot/sdk/pricing` would collide.
- *
- * `satisfies` is what makes these safe to depend on: drop a member from the spec
- * and this file stops compiling, so the two cannot drift apart silently.
+ * Suffixed `Values` because the spec type owns the bare name. `satisfies` stops
+ * them drifting: drop a member from the spec and this no longer compiles.
  */
 
 export const PricingModelValues = {

--- a/packages/epilot-sdk-v2/__tests__/additional-types.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/additional-types.test.ts
@@ -1,12 +1,12 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { SRC_DIR, clientsWith } from './helpers/clients';
 import type { AvailabilityDate, Cart, PriceTierEnhanced } from '../src/apis/pricing';
 
-const CLIENTS_DIR = resolve(__dirname, '../../../clients');
-const TYPES_DIR = resolve(__dirname, '../src/types');
-const APIS_DIR = resolve(__dirname, '../src/apis');
+const TYPES_DIR = resolve(SRC_DIR, 'types');
+const APIS_DIR = resolve(SRC_DIR, 'apis');
 
 /**
  * Types that are hand-written in a client's `additional-types.ts` (i.e. not part
@@ -15,10 +15,7 @@ const APIS_DIR = resolve(__dirname, '../src/apis');
  * re-declare them. See clients/pricing-client/src/additional-types.ts.
  */
 describe('additional types are exposed by the SDK', () => {
-  const clientsWithAdditionalTypes = readdirSync(CLIENTS_DIR, { withFileTypes: true })
-    .filter((d) => d.isDirectory() && d.name.endsWith('-client'))
-    .filter((d) => existsSync(resolve(CLIENTS_DIR, d.name, 'src/additional-types.ts')))
-    .map((d) => ({ dirName: d.name, kebabName: d.name.replace(/-client$/, '') }));
+  const clientsWithAdditionalTypes = clientsWith('additional-types.ts');
 
   it('finds at least one client with additional types', () => {
     expect(clientsWithAdditionalTypes.length).toBeGreaterThan(0);

--- a/packages/epilot-sdk-v2/__tests__/helpers/clients.ts
+++ b/packages/epilot-sdk-v2/__tests__/helpers/clients.ts
@@ -1,0 +1,15 @@
+import { existsSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const CLIENTS_DIR = resolve(__dirname, '../../../../clients');
+export const SRC_DIR = resolve(__dirname, '../../src');
+
+/**
+ * Clients carrying a hand-written `src/<relPath>`, mirroring the discovery in
+ * scripts/generate-sdk-v2.ts so a client added there is covered here too.
+ */
+export const clientsWith = (relPath: string) =>
+  readdirSync(CLIENTS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.endsWith('-client'))
+    .filter((d) => existsSync(resolve(CLIENTS_DIR, d.name, 'src', relPath)))
+    .map((d) => ({ dirName: d.name, kebabName: d.name.replace(/-client$/, '') }));

--- a/packages/epilot-sdk-v2/__tests__/models.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/models.test.ts
@@ -52,7 +52,10 @@ describe('runtime models are exposed by the SDK', () => {
 
   // The `<SpecType>Values` naming convention is what ties a hand-written map back to
   // the schema it mirrors, in both directions: a spec member gained or lost fails here.
-  it.each(clientsWithModels)('$dirName `<SpecType>Values` maps match their spec enum', async ({ dirName, kebabName }) => {
+  it.each(clientsWithModels)('$dirName `<SpecType>Values` maps match their spec enum', async ({
+    dirName,
+    kebabName,
+  }) => {
     const schemas = readSpec(dirName)?.components?.schemas ?? {};
     const api = await import(`../src/apis/${kebabName}`);
 

--- a/packages/epilot-sdk-v2/__tests__/models.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/models.test.ts
@@ -1,13 +1,20 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import { CLIENTS_DIR, SRC_DIR, clientsWith } from './helpers/clients';
 import { DynamicTariffModeValues, PricingModelValues } from '../src/apis/pricing';
 import { RelationAffinityMode } from '../src/apis/entity';
 
-const CLIENTS_DIR = resolve(__dirname, '../../../clients');
-const MODELS_DIR = resolve(__dirname, '../src/models');
-const APIS_DIR = resolve(__dirname, '../src/apis');
+const MODELS_DIR = resolve(SRC_DIR, 'models');
+
+const readSpec = (dirName: string) => {
+  const specPath = ['src/openapi.json', 'src/openapi-runtime.json']
+    .map((rel) => resolve(CLIENTS_DIR, dirName, rel))
+    .find(existsSync);
+
+  return specPath ? JSON.parse(readFileSync(specPath, 'utf-8')) : undefined;
+};
 
 /**
  * A client's `schema-model.ts` carries runtime values, not just types. It must be
@@ -16,28 +23,48 @@ const APIS_DIR = resolve(__dirname, '../src/apis');
  * be `undefined` for SDK consumers. See scripts/generate-sdk-v2.ts `copyModels`.
  */
 describe('runtime models are exposed by the SDK', () => {
-  const clientsWithModels = readdirSync(CLIENTS_DIR, { withFileTypes: true })
-    .filter((d) => d.isDirectory() && d.name.endsWith('-client'))
-    .filter((d) => existsSync(resolve(CLIENTS_DIR, d.name, 'src/schema-model.ts')))
-    .map((d) => ({ dirName: d.name, kebabName: d.name.replace(/-client$/, '') }));
+  const clientsWithModels = clientsWith('schema-model.ts');
 
   it('finds at least one client with a schema model', () => {
+    // Guards against the generator silently skipping every client, which is
+    // otherwise a green build that quietly exports nothing.
     expect(clientsWithModels.length).toBeGreaterThan(0);
   });
 
-  it.each(clientsWithModels)('$dirName model is copied and re-exported as values', ({ kebabName }) => {
+  it.each(clientsWithModels)('$dirName model is copied into the SDK', ({ kebabName }) => {
     const copied = resolve(MODELS_DIR, `${kebabName}-model.ts`);
     expect(existsSync(copied), `${copied} is missing — run pnpm generate-sdk`).toBe(true);
 
-    // A .d.ts alongside it would shadow the values away again.
-    expect(existsSync(resolve(MODELS_DIR, `${kebabName}-model.d.ts`))).toBe(false);
-
     // The copied file must not keep pointing at the client's own './openapi'.
     expect(readFileSync(copied, 'utf-8')).not.toMatch(/from '\.\/openapi'/);
+  });
 
-    const apiFile = readFileSync(resolve(APIS_DIR, `${kebabName}.ts`), 'utf-8');
-    expect(apiFile).toContain(`export * from '../models/${kebabName}-model'`);
-    expect(apiFile).not.toContain(`export type * from '../models/${kebabName}-model'`);
+  it.each(clientsWithModels)('$dirName model values survive to runtime', async ({ dirName, kebabName }) => {
+    const source = readFileSync(resolve(CLIENTS_DIR, dirName, 'src/schema-model.ts'), 'utf-8');
+    const exported = [...source.matchAll(/^export (?:const|enum) (\w+)/gm)].map(([, name]) => name);
+    expect(exported.length).toBeGreaterThan(0);
+
+    const api = await import(`../src/apis/${kebabName}`);
+    for (const name of exported) {
+      expect(api[name], `${name} is not a runtime value in @epilot/sdk/${kebabName}`).toBeDefined();
+    }
+  });
+
+  // The `<SpecType>Values` naming convention is what ties a hand-written map back to
+  // the schema it mirrors, in both directions: a spec member gained or lost fails here.
+  it.each(clientsWithModels)('$dirName `<SpecType>Values` maps match their spec enum', async ({ dirName, kebabName }) => {
+    const schemas = readSpec(dirName)?.components?.schemas ?? {};
+    const api = await import(`../src/apis/${kebabName}`);
+
+    for (const name of Object.keys(api).filter((key) => key.endsWith('Values'))) {
+      const specName = name.replace(/Values$/, '');
+      const specEnum = schemas[specName]?.enum;
+
+      // A map whose name resolves to no spec enum is silently unchecked, which is
+      // the drift this test exists to catch — the suffix is the whole tie.
+      expect(specEnum, `${name} matches no components.schemas.${specName}.enum — check the name`).toBeDefined();
+      expect(Object.values(api[name]).sort(), `${name} has drifted from the spec`).toEqual([...specEnum].sort());
+    }
   });
 
   it('exposes the entity relation affinity enum through @epilot/sdk/entity', () => {

--- a/packages/epilot-sdk-v2/__tests__/models.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/models.test.ts
@@ -1,0 +1,53 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { DynamicTariffModeValues, PricingModelValues } from '../src/apis/pricing';
+import { RelationAffinityMode } from '../src/apis/entity';
+
+const CLIENTS_DIR = resolve(__dirname, '../../../clients');
+const MODELS_DIR = resolve(__dirname, '../src/models');
+const APIS_DIR = resolve(__dirname, '../src/apis');
+
+/**
+ * A client's `schema-model.ts` carries runtime values, not just types. It must be
+ * copied as a real `.ts` and re-exported with `export *` — copied as a `.d.ts` (the
+ * treatment `additional-types.ts` gets) every one of these would type-check and then
+ * be `undefined` for SDK consumers. See scripts/generate-sdk-v2.ts `copyModels`.
+ */
+describe('runtime models are exposed by the SDK', () => {
+  const clientsWithModels = readdirSync(CLIENTS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.endsWith('-client'))
+    .filter((d) => existsSync(resolve(CLIENTS_DIR, d.name, 'src/schema-model.ts')))
+    .map((d) => ({ dirName: d.name, kebabName: d.name.replace(/-client$/, '') }));
+
+  it('finds at least one client with a schema model', () => {
+    expect(clientsWithModels.length).toBeGreaterThan(0);
+  });
+
+  it.each(clientsWithModels)('$dirName model is copied and re-exported as values', ({ kebabName }) => {
+    const copied = resolve(MODELS_DIR, `${kebabName}-model.ts`);
+    expect(existsSync(copied), `${copied} is missing — run pnpm generate-sdk`).toBe(true);
+
+    // A .d.ts alongside it would shadow the values away again.
+    expect(existsSync(resolve(MODELS_DIR, `${kebabName}-model.d.ts`))).toBe(false);
+
+    // The copied file must not keep pointing at the client's own './openapi'.
+    expect(readFileSync(copied, 'utf-8')).not.toMatch(/from '\.\/openapi'/);
+
+    const apiFile = readFileSync(resolve(APIS_DIR, `${kebabName}.ts`), 'utf-8');
+    expect(apiFile).toContain(`export * from '../models/${kebabName}-model'`);
+    expect(apiFile).not.toContain(`export type * from '../models/${kebabName}-model'`);
+  });
+
+  it('exposes the entity relation affinity enum through @epilot/sdk/entity', () => {
+    expect(RelationAffinityMode.WEAK).toBe('weak');
+    expect(RelationAffinityMode.STRONG).toBe('strong');
+  });
+
+  it('exposes the pricing enum values through @epilot/sdk/pricing', () => {
+    expect(PricingModelValues.perUnit).toBe('per_unit');
+    expect(Object.values(PricingModelValues)).toContain('external_getag');
+    expect(DynamicTariffModeValues.manual).toBe('manual');
+  });
+});

--- a/packages/epilot-sdk-v2/src/apis/entity.ts
+++ b/packages/epilot-sdk-v2/src/apis/entity.ts
@@ -10,6 +10,7 @@ export type { TokenArg } from '../authorize';
 import type { Client } from '../types/entity';
 export type * from '../types/entity';
 export type { OpenAPIClient } from 'openapi-client-axios';
+export * from '../models/entity-model';
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const loadDefinition = (): Document => {

--- a/packages/epilot-sdk-v2/src/apis/pricing.ts
+++ b/packages/epilot-sdk-v2/src/apis/pricing.ts
@@ -11,6 +11,7 @@ import type { Client } from '../types/pricing';
 export type * from '../types/pricing';
 export type * from '../types/pricing-additional';
 export type { OpenAPIClient } from 'openapi-client-axios';
+export * from '../models/pricing-model';
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 const loadDefinition = (): Document => {

--- a/packages/epilot-sdk-v2/src/models/entity-model.ts
+++ b/packages/epilot-sdk-v2/src/models/entity-model.ts
@@ -1,9 +1,7 @@
 /* Auto-copied from entity-client/src/schema-model.ts */
 export enum RelationAffinityMode {
-  /**
-   * For strong affinity mode on a relation attribute, deleting or creating the parent or the relation linkage will trigger a CASCADE delete or create to the relation entity itself.
-   * For weak affinity mode on a relation attribute, deleting or creating the parent or the relation linkage will NOT trigger a CASCADE delete or create to the relation entity itself.
-   */
+  /** Deleting or creating the parent or the linkage does NOT cascade to the relation entity. */
   WEAK = 'weak',
+  /** Deleting or creating the parent or the linkage cascades to the relation entity. */
   STRONG = 'strong',
 }

--- a/packages/epilot-sdk-v2/src/models/entity-model.ts
+++ b/packages/epilot-sdk-v2/src/models/entity-model.ts
@@ -1,0 +1,9 @@
+/* Auto-copied from entity-client/src/schema-model.ts */
+export enum RelationAffinityMode {
+  /**
+   * For strong affinity mode on a relation attribute, deleting or creating the parent or the relation linkage will trigger a CASCADE delete or create to the relation entity itself.
+   * For weak affinity mode on a relation attribute, deleting or creating the parent or the relation linkage will NOT trigger a CASCADE delete or create to the relation entity itself.
+   */
+  WEAK = 'weak',
+  STRONG = 'strong',
+}

--- a/packages/epilot-sdk-v2/src/models/pricing-model.ts
+++ b/packages/epilot-sdk-v2/src/models/pricing-model.ts
@@ -1,0 +1,42 @@
+/* Auto-copied from pricing-client/src/schema-model.ts */
+import type { DynamicTariffMode, MarkupPricingModel, PricingModel, TypeGetAg } from '../types/pricing';
+
+/**
+ * Runtime companions for spec enums.
+ *
+ * `components.schemas` enums generate a TypeScript union — a type, erased at
+ * runtime. Consumers that need the values themselves (a lookup, a `switch`
+ * default, an `Object.values()` allowlist) otherwise re-declare them by hand;
+ * `@epilot/pricing` carries exactly such a copy in `src/prices/constants.ts`.
+ *
+ * Named `<SpecType>Values` because the spec type already owns the bare name —
+ * exporting both from `@epilot/sdk/pricing` would collide.
+ *
+ * `satisfies` is what makes these safe to depend on: drop a member from the spec
+ * and this file stops compiling, so the two cannot drift apart silently.
+ */
+
+export const PricingModelValues = {
+  perUnit: 'per_unit',
+  tieredGraduated: 'tiered_graduated',
+  tieredVolume: 'tiered_volume',
+  tieredFlatFee: 'tiered_flatfee',
+  dynamicTariff: 'dynamic_tariff',
+  externalGetAG: 'external_getag',
+} as const satisfies Record<string, PricingModel>;
+
+export const MarkupPricingModelValues = {
+  perUnit: 'per_unit',
+  tieredVolume: 'tiered_volume',
+  tieredFlatFee: 'tiered_flatfee',
+} as const satisfies Record<string, MarkupPricingModel>;
+
+export const TypeGetAgValues = {
+  basePrice: 'base_price',
+  workPrice: 'work_price',
+} as const satisfies Record<string, TypeGetAg>;
+
+export const DynamicTariffModeValues = {
+  dayAheadMarket: 'day_ahead_market',
+  manual: 'manual',
+} as const satisfies Record<string, DynamicTariffMode>;

--- a/packages/epilot-sdk-v2/src/models/pricing-model.ts
+++ b/packages/epilot-sdk-v2/src/models/pricing-model.ts
@@ -3,11 +3,12 @@ import type { DynamicTariffMode, MarkupPricingModel, PricingModel, TypeGetAg } f
 
 /**
  * Runtime companions for spec enums, for consumers that need the values and not
- * just the union type — `@epilot/pricing` re-declares these in
- * `src/prices/constants.ts` today.
+ * just the union type.
  *
- * Suffixed `Values` because the spec type owns the bare name. `satisfies` stops
- * them drifting: drop a member from the spec and this no longer compiles.
+ * Suffixed `Values` because the spec type owns the bare name. That suffix is also
+ * the contract: `packages/epilot-sdk-v2/__tests__/models.test.ts` checks every
+ * `<SpecType>Values` map against `components.schemas.<SpecType>.enum`, so a member
+ * added to or removed from the spec fails the build rather than drifting silently.
  */
 
 export const PricingModelValues = {

--- a/packages/epilot-sdk-v2/src/models/pricing-model.ts
+++ b/packages/epilot-sdk-v2/src/models/pricing-model.ts
@@ -2,18 +2,12 @@
 import type { DynamicTariffMode, MarkupPricingModel, PricingModel, TypeGetAg } from '../types/pricing';
 
 /**
- * Runtime companions for spec enums.
+ * Runtime companions for spec enums, for consumers that need the values and not
+ * just the union type — `@epilot/pricing` re-declares these in
+ * `src/prices/constants.ts` today.
  *
- * `components.schemas` enums generate a TypeScript union — a type, erased at
- * runtime. Consumers that need the values themselves (a lookup, a `switch`
- * default, an `Object.values()` allowlist) otherwise re-declare them by hand;
- * `@epilot/pricing` carries exactly such a copy in `src/prices/constants.ts`.
- *
- * Named `<SpecType>Values` because the spec type already owns the bare name —
- * exporting both from `@epilot/sdk/pricing` would collide.
- *
- * `satisfies` is what makes these safe to depend on: drop a member from the spec
- * and this file stops compiling, so the two cannot drift apart silently.
+ * Suffixed `Values` because the spec type owns the bare name. `satisfies` stops
+ * them drifting: drop a member from the spec and this no longer compiles.
  */
 
 export const PricingModelValues = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1951,7 +1951,7 @@ importers:
         specifier: ^10.9.1
         version: 10.9.2(@types/node@24.2.0)(typescript@4.9.5)
       typescript:
-        specifier: ^4.1.3
+        specifier: ^4.9.3
         version: 4.9.5
       webpack:
         specifier: ^5.18.0

--- a/scripts/generate-sdk-v2.ts
+++ b/scripts/generate-sdk-v2.ts
@@ -5,6 +5,7 @@
  * - Copies openapi-runtime.json definitions
  * - Copies openapi.d.ts type files
  * - Copies hand-written additional-types.ts type files
+ * - Copies hand-written schema-model.ts runtime modules
  * - Generates per-API lazy loader files (apis/*.ts)
  * - Generates the API registry (apis/_registry.ts)
  * - Updates package.json subpath exports
@@ -22,6 +23,7 @@ const DEFS_DIR = resolve(V2_DIR, 'src/definitions');
 const RUNTIME_DEFS_DIR = resolve(V2_DIR, 'definitions');
 const TYPES_DIR = resolve(V2_DIR, 'src/types');
 const APIS_DIR = resolve(V2_DIR, 'src/apis');
+const MODELS_DIR = resolve(V2_DIR, 'src/models');
 
 // Map client directory name -> SDK api name (camelCase)
 const toCamelCase = (name: string): string => {
@@ -35,6 +37,7 @@ type ClientInfo = {
   hasDefinition: boolean;
   hasTypes: boolean;
   hasAdditionalTypes: boolean;
+  hasModel: boolean;
 };
 
 const discoverClients = (): ClientInfo[] => {
@@ -54,6 +57,7 @@ const discoverClients = (): ClientInfo[] => {
       hasDefinition: existsSync(resolve(clientDir, 'openapi-runtime.json')),
       hasTypes: existsSync(resolve(clientDir, 'openapi.d.ts')),
       hasAdditionalTypes: existsSync(resolve(clientDir, 'additional-types.ts')),
+      hasModel: existsSync(resolve(clientDir, 'schema-model.ts')),
     };
   });
 };
@@ -203,6 +207,37 @@ const copyAdditionalTypes = (clients: ClientInfo[]) => {
     content = `/* Auto-copied from ${client.dirName}/src/additional-types.ts */\n${content}`;
 
     const dest = resolve(TYPES_DIR, `${client.kebabName}-additional.d.ts`);
+    writeFileSync(dest, content);
+  }
+};
+
+/**
+ * Copies the hand-written `schema-model.ts` of a client into the SDK.
+ *
+ * Unlike `additional-types.ts`, this module carries **runtime values** (enums,
+ * frozen constants) that mirror the spec — a shared allowlist a consumer needs to
+ * evaluate, not just to type against. It is therefore copied as a real `.ts` and
+ * re-exported with `export *` rather than `export type *`; a `.d.ts` would
+ * type-check and then be `undefined` at runtime for every SDK consumer.
+ *
+ * A name exported here must not also be a `components.schemas` entry, or the two
+ * `export`s in the API entry file collide and the build fails. Name the runtime
+ * companion of a spec type `<SpecType>Values`.
+ */
+const copyModels = (clients: ClientInfo[]) => {
+  mkdirSync(MODELS_DIR, { recursive: true });
+
+  for (const client of clients) {
+    if (!client.hasModel) continue;
+    const src = resolve(CLIENTS_DIR, client.dirName, 'src/schema-model.ts');
+    let content = readFileSync(src, 'utf-8');
+
+    // The client resolves generated types via './openapi', in the SDK they live
+    // under ../types, named after the API.
+    content = content.replace(/(\bfrom\s+')\.\/openapi(')/g, `$1../types/${client.kebabName}$2`);
+    content = `/* Auto-copied from ${client.dirName}/src/schema-model.ts */\n${content}`;
+
+    const dest = resolve(MODELS_DIR, `${client.kebabName}-model.ts`);
     writeFileSync(dest, content);
   }
 };
@@ -366,6 +401,11 @@ const generateApiFile = (client: ClientInfo): string => {
     lines.push(`export type { OpenAPIClient } from 'openapi-client-axios'`);
   } else {
     lines.push(`import type { AxiosInstance } from 'axios'`);
+  }
+
+  if (client.hasModel) {
+    // Values, not just types — see copyModels.
+    lines.push(`export * from '../models/${client.kebabName}-model'`);
   }
 
   lines.push(
@@ -1070,6 +1110,7 @@ const main = () => {
   console.log('Copying types...');
   copyTypes(clients);
   copyAdditionalTypes(clients);
+  copyModels(clients);
 
   console.log('Generating per-API files...');
   mkdirSync(APIS_DIR, { recursive: true });
@@ -1108,6 +1149,7 @@ const main = () => {
   console.log(`  - ${validClients.length} definition files`);
   console.log(`  - ${clients.filter((c) => c.hasTypes).length} type files`);
   console.log(`  - ${clients.filter((c) => c.hasAdditionalTypes).length} additional type files`);
+  console.log(`  - ${clients.filter((c) => c.hasModel).length} model files`);
   console.log(`  - ${validClients.length} API entry files`);
   console.log(`  - 1 registry file`);
   console.log(`  - ${docCount} API docs + index`);

--- a/scripts/generate-sdk-v2.ts
+++ b/scripts/generate-sdk-v2.ts
@@ -188,55 +188,57 @@ const copyTypes = (clients: ClientInfo[]) => {
 };
 
 /**
- * Copies the hand-written `additional-types.ts` of a client (types that are not
- * part of the OpenAPI specification but are still part of the client's public
- * API surface) into the SDK types directory, so the SDK exposes the exact same
- * types as the standalone client package.
- */
-const copyAdditionalTypes = (clients: ClientInfo[]) => {
-  mkdirSync(TYPES_DIR, { recursive: true });
-
-  for (const client of clients) {
-    if (!client.hasAdditionalTypes) continue;
-    const src = resolve(CLIENTS_DIR, client.dirName, 'src/additional-types.ts');
-    let content = readFileSync(src, 'utf-8');
-
-    // The client resolves generated types via './openapi', in the SDK they live
-    // in a sibling file named after the API.
-    content = content.replace(/(\bfrom\s+')\.\/openapi(')/g, `$1./${client.kebabName}$2`);
-    content = `/* Auto-copied from ${client.dirName}/src/additional-types.ts */\n${content}`;
-
-    const dest = resolve(TYPES_DIR, `${client.kebabName}-additional.d.ts`);
-    writeFileSync(dest, content);
-  }
-};
-
-/**
- * Copies a client's hand-written `schema-model.ts` into the SDK.
+ * Copies a hand-written client module into the SDK, repointing its `./openapi`
+ * import at the SDK's copy of the generated types.
  *
- * It carries runtime values, so it is copied as a real `.ts` and re-exported with
- * `export *`; the `.d.ts` + `export type *` treatment `additional-types.ts` gets
- * would leave every value `undefined` at runtime. Names must not clash with
- * `components.schemas` entries — the two exports in the API entry file would
- * collide — hence the `<SpecType>Values` convention.
+ * `additional-types.ts` holds types only, so it lands as a `.d.ts` re-exported
+ * with `export type *`. `schema-model.ts` holds runtime values, so it lands as a
+ * real `.ts` re-exported with `export *` — the `.d.ts` treatment would leave
+ * every value `undefined` for SDK consumers. See CONTRIBUTING.md.
  */
-const copyModels = (clients: ClientInfo[]) => {
-  mkdirSync(MODELS_DIR, { recursive: true });
+const copyHandWritten = (
+  clients: ClientInfo[],
+  opts: {
+    has: (client: ClientInfo) => boolean;
+    srcFile: string;
+    destDir: string;
+    destFile: (kebabName: string) => string;
+    typesImport: (kebabName: string) => string;
+  },
+) => {
+  mkdirSync(opts.destDir, { recursive: true });
 
   for (const client of clients) {
-    if (!client.hasModel) continue;
-    const src = resolve(CLIENTS_DIR, client.dirName, 'src/schema-model.ts');
+    if (!opts.has(client)) continue;
+    const src = resolve(CLIENTS_DIR, client.dirName, 'src', opts.srcFile);
     let content = readFileSync(src, 'utf-8');
 
     // The client resolves generated types via './openapi', in the SDK they live
-    // under ../types, named after the API.
-    content = content.replace(/(\bfrom\s+')\.\/openapi(')/g, `$1../types/${client.kebabName}$2`);
-    content = `/* Auto-copied from ${client.dirName}/src/schema-model.ts */\n${content}`;
+    // in a file named after the API.
+    content = content.replace(/(\bfrom\s+')\.\/openapi(')/g, `$1${opts.typesImport(client.kebabName)}$2`);
+    content = `/* Auto-copied from ${client.dirName}/src/${opts.srcFile} */\n${content}`;
 
-    const dest = resolve(MODELS_DIR, `${client.kebabName}-model.ts`);
-    writeFileSync(dest, content);
+    writeFileSync(resolve(opts.destDir, opts.destFile(client.kebabName)), content);
   }
 };
+
+const copyAdditionalTypes = (clients: ClientInfo[]) =>
+  copyHandWritten(clients, {
+    has: (client) => client.hasAdditionalTypes,
+    srcFile: 'additional-types.ts',
+    destDir: TYPES_DIR,
+    destFile: (kebabName) => `${kebabName}-additional.d.ts`,
+    typesImport: (kebabName) => `./${kebabName}`,
+  });
+
+const copyModels = (clients: ClientInfo[]) =>
+  copyHandWritten(clients, {
+    has: (client) => client.hasModel,
+    srcFile: 'schema-model.ts',
+    destDir: MODELS_DIR,
+    destFile: (kebabName) => `${kebabName}-model.ts`,
+    typesImport: (kebabName) => `../types/${kebabName}`,
+  });
 
 type SchemaDoc = {
   name: string;

--- a/scripts/generate-sdk-v2.ts
+++ b/scripts/generate-sdk-v2.ts
@@ -212,17 +212,13 @@ const copyAdditionalTypes = (clients: ClientInfo[]) => {
 };
 
 /**
- * Copies the hand-written `schema-model.ts` of a client into the SDK.
+ * Copies a client's hand-written `schema-model.ts` into the SDK.
  *
- * Unlike `additional-types.ts`, this module carries **runtime values** (enums,
- * frozen constants) that mirror the spec — a shared allowlist a consumer needs to
- * evaluate, not just to type against. It is therefore copied as a real `.ts` and
- * re-exported with `export *` rather than `export type *`; a `.d.ts` would
- * type-check and then be `undefined` at runtime for every SDK consumer.
- *
- * A name exported here must not also be a `components.schemas` entry, or the two
- * `export`s in the API entry file collide and the build fails. Name the runtime
- * companion of a spec type `<SpecType>Values`.
+ * It carries runtime values, so it is copied as a real `.ts` and re-exported with
+ * `export *`; the `.d.ts` + `export type *` treatment `additional-types.ts` gets
+ * would leave every value `undefined` at runtime. Names must not clash with
+ * `components.schemas` entries — the two exports in the API entry file would
+ * collide — hence the `<SpecType>Values` convention.
  */
 const copyModels = (clients: ClientInfo[]) => {
   mkdirSync(MODELS_DIR, { recursive: true });


### PR DESCRIPTION
## Why

The SDK generator could only ever re-export **types** from a client's hand-written modules. `additional-types.ts` is copied to a `.d.ts` (`generate-sdk-v2.ts` `copyAdditionalTypes`) and re-exported with `export type *`, so a `const` or `enum` placed there type-checks and is then `undefined` at runtime for every `@epilot/sdk/<api>` consumer.

That leaves no home for a value the SDK ought to own — a shared allowlist a consumer needs to *evaluate*, not just type against. The pure-OpenAPI route has the mirror problem: a `components.schemas` enum generates a union type, erased at runtime; the values exist only via the `@epilot/sdk/<api>/openapi.json` subpath, which is the whole spec and far too heavy to pull into an MFE bundle for a handful of strings.

This is groundwork for sharing the conditional-pricing attribute-type allowlists (`RELATION_ATTRIBUTE_TYPES`, the `overridable_attribute` type allowlist), which are currently hand-copied across `entity-api`, `epilot360-entity-builder`, `epilot360-entity-builder-v2` and `epilot360-integration-hub`. Those consumers need `.has(type)` at runtime, so neither existing mechanism could carry them.

## What changed

**`scripts/generate-sdk-v2.ts` — new `copyModels`.** A client's `src/schema-model.ts` is copied as a real `.ts` to `packages/epilot-sdk-v2/src/models/{api}-model.ts` and re-exported with `export *`, so values survive. Same `./openapi` → `../types/{api}` import rewrite that `copyAdditionalTypes` does. `additional-types.ts` keeps its type-only treatment — the two files now mean different things, documented in CONTRIBUTING.md.

**Fixes an existing gap.** `RelationAffinityMode` has always been exported from `@epilot/entity-client` but was unreachable through `@epilot/sdk/entity`, because the generator never looked at `schema-model.ts`. It is now available from both.

**`clients/pricing-client/src/schema-model.ts`** (new) — runtime companions for four spec enums: `PricingModelValues`, `MarkupPricingModelValues`, `TypeGetAgValues`, `DynamicTariffModeValues`. These are exactly the values `@epilot/pricing` hand-maintains today in `src/prices/constants.ts`, so none is speculative; it already depends on `@epilot/sdk`, and can drop its copies once this releases.

## Two decisions worth a look

**The `{SpecType}Values` naming isn't cosmetic.** `PricingModel` and friends are already `components.schemas` entries, so an enum of the same name collides with `export type * from '../types/pricing'` in the same API entry file and fails the build. Entity got away with the bare `RelationAffinityMode` only because it isn't in the spec.

**`as const satisfies Record<string, PricingModel>` is what makes these safe to depend on.** It ties each hand-written list back to the generated union, so the two can't drift silently. Verified it actually bites — adding a member not in the spec fails with `TS1360`.

`BillingPeriod` is a fifth candidate; left out because `@epilot/pricing` exports it as a `Set`, so the shape wants a decision first.

## Test plan

- [x] **CI green on the current head** — Test, Lint and CodeQL all pass
- [x] `pnpm build` (tsup + dts) clean across all 51 APIs — this is where a name collision would surface
- [x] 5 new tests in `packages/epilot-sdk-v2/__tests__/models.test.ts`, covering the file layout, the `export *` (not `export type *`) re-export, and — the real regression — that the values are non-`undefined` at runtime
- [x] Values verified in the **built** bundle, not just source: `dist/apis/entity.cjs` → `RelationAffinityMode: {"WEAK":"weak","STRONG":"strong"}`; `dist/apis/pricing.cjs` → `PricingModelValues: {"perUnit":"per_unit", …}`
- [x] `@epilot/entity-client` and `@epilot/pricing-client` still build and expose the values from their own `dist/` (the `build:patch` sed only strips `openapi` re-exports, so `schema-model` survives)
- [x] Drift guard confirmed: a member not in the spec fails with `TS1360`
- [x] `pnpm lint` clean (523 files)

## Follow-up (not in this PR)

Once this releases: add `entity-client/src/schema-model.ts` with the relation + overridable allowlists, then delete the four copies in `entity-api`, `entity-builder`, `entity-builder-v2` and `integration-hub`. Worth deciding then whether the API constant keeps the name `VARIANT_OVERRIDABLE_ATTRIBUTE_TYPES` now that the flag is `overridable_attribute`.