### PR TITLE
ci: release the SDK on any change that alters what it ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,15 @@ jobs:
         id: check
         run: |
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
-          if echo "$CHANGED_FILES" | grep -q '^clients/.*/openapi\.json$'; then
+
+          # Anything that changes what @epilot/sdk ships: a spec, a hand-written client
+          # module, the generator, or the SDK's own runtime.
+          SDK_PATHS='^(clients/.*/openapi\.json$|clients/[^/]+/src/(schema-model|additional-types|index)\.ts$|scripts/generate-sdk-v2\.ts$|packages/epilot-sdk-v2/src/)'
+          # ...but not the generated output, which the auto-release commit itself rewrites.
+          # Matching it would make that commit re-trigger this job in a loop.
+          SDK_GENERATED='^packages/epilot-sdk-v2/src/(apis|types|models|definitions|docs)/|^packages/epilot-sdk-v2/src/client-map\.ts$'
+
+          if echo "$CHANGED_FILES" | grep -E "$SDK_PATHS" | grep -qvE "$SDK_GENERATED"; then
             echo "sdk=true" >> "$GITHUB_OUTPUT"
           else
             echo "sdk=false" >> "$GITHUB_OUTPUT"
@@ -159,7 +167,8 @@ jobs:
             [ -n "$COMMIT_MSG" ] && COMMIT_MSG="$COMMIT_MSG, "
             COMMIT_MSG="${COMMIT_MSG}@epilot/cli@${CLI_VERSION}"
           fi
-          git commit -m "$COMMIT_MSG"
+          # `[skip release]` stops this commit from re-triggering the job (see the job `if`).
+          git commit -m "$COMMIT_MSG [skip release]"
 
           for TAG in $TAGS; do
             git tag "$TAG"


### PR DESCRIPTION
## Why

The `auto-release` gate fires only on `clients/*/openapi.json`. That misses everything else that changes what `@epilot/sdk` actually ships:

- **The SDK's own runtime** — `proxy.ts`, `retry.ts`, `client-factory.ts`, `authorize.ts`, `overrides.ts`, `large-response.ts`. A bug fix in any of these never publishes.
- **Hand-written client modules** — `schema-model.ts`, `additional-types.ts`, `index.ts`.
- **The generator** — `scripts/generate-sdk-v2.ts`, which changes the output of all 51 APIs.

This is not hypothetical: #464 and #469 both landed on `main` and published nothing. #464 only reached npm ~90 minutes later, as a passenger on #467, an unrelated spec PR. #469 is still unpublished.

## The trap this has to avoid

The `auto-release` job commits back to `main`, and that commit touches generated SDK output. From `5e39d9ce`:

```
packages/epilot-sdk-v2/package.json                  |   2 +-
packages/epilot-sdk-v2/src/types/entity-mapping.d.ts | 197 +++-
```

So a naive `packages/epilot-sdk-v2/src/**` pattern would make **the release commit re-trigger its own gate** → bump → push → trigger → an unbounded release loop. The existing `[skip release]` guard does not save you, because the release commit's message is `@epilot/sdk@2.19.12, @epilot/cli@0.1.141`.

The gate works today partly by accident: the release commit happens to match nothing in it. Widening removes that accidental protection, so this PR restores it deliberately.

## What changed

**The gate matches hand-written paths and excludes generated output:**

```bash
SDK_PATHS='^(clients/.*/openapi\.json$|clients/[^/]+/src/(schema-model|additional-types|index)\.ts$|scripts/generate-sdk-v2\.ts$|packages/epilot-sdk-v2/src/)'
SDK_GENERATED='^packages/epilot-sdk-v2/src/(apis|types|models|definitions|docs)/|^packages/epilot-sdk-v2/src/client-map\.ts$'

if echo "$CHANGED_FILES" | grep -E "$SDK_PATHS" | grep -qvE "$SDK_GENERATED"; then
```

A denylist for the generated dirs rather than an allowlist of runtime files, so a new hand-written module is covered by default instead of silently missed.

**The release commit now carries `[skip release]`**, which the job's own `if` already honours — a second layer, in case the exclusion is later widened carelessly. The path exclusion alone closes the loop; this makes it hard to reopen by accident.

The CLI gate is untouched.

## Test plan

Ran the new expression against real commit file lists, including the actual release commit:

| Case | Expected | Result |
|---|---|---|
| Spec change (today's only trigger) | trigger | ✅ `sdk=true` |
| #464 — generator + pricing `schema-model.ts` | trigger | ✅ `sdk=true` |
| #469 — entity + pricing allowlists | trigger | ✅ `sdk=true` |
| SDK runtime fix (`src/retry.ts`) | trigger | ✅ `sdk=true` |
| Generator change alone | trigger | ✅ `sdk=true` |
| **The auto-release commit `5e39d9ce` itself** | **no trigger** | ✅ `sdk=false` |
| Docs-only | no trigger | ✅ `sdk=false` |
| Changeset-only | no trigger | ✅ `sdk=false` |
| Generated output only | no trigger | ✅ `sdk=false` |

- [x] `.github/workflows/ci.yml` parses as valid YAML, all five jobs intact
- [x] `pnpm lint` clean

## Out of scope

This covers `@epilot/sdk` only. The **client packages** (`@epilot/pricing-client` et al.) publish through changesets, which is manual — that is why `pricing-client` sits at 3.56.2 in the repo against 3.55.1 on npm. Whether that should auto-publish on merge is a separate decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXhwfYV419Bodt42E3aw2C)_