### PR TITLE
ci: release the SDK when any client source file it ships from changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,9 @@ jobs:
         id: check
         run: |
           CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
-          if echo "$CHANGED_FILES" | grep -q '^clients/.*/openapi\.json$'; then
+          # All client source files the SDK generator copies into @epilot/sdk:
+          # the specs plus the hand-written type/runtime modules.
+          if echo "$CHANGED_FILES" | grep -qE '^clients/[^/]+/src/(openapi\.json|openapi\.d\.ts|openapi-runtime\.json|additional-types\.ts|schema-model\.ts)$'; then
             echo "sdk=true" >> "$GITHUB_OUTPUT"
           else
             echo "sdk=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Minimal alternative to #470.

The auto-release gate only fired on `clients/*/src/openapi.json`, but the SDK generator (`scripts/generate-sdk-v2.ts`) copies **five** files out of each `clients/*/src/` into `@epilot/sdk`: the spec, `openapi.d.ts`, `openapi-runtime.json`, `additional-types.ts` and `schema-model.ts`. A change to any of the other four landed on main unpublished (#464, #469 — both `schema-model.ts` changes) and only shipped when a later spec PR swept it up.

This PR extends the single grep pattern to match all five client source inputs. **Nothing else changes**: because the gate only watches `clients/` and the auto-release commit only ever touches `packages/epilot-sdk-v2/` and `README.md`, the release commit structurally cannot re-trigger the job — so no exclusion regex and no `[skip release]` marker are needed (the parts of #470 this replaces).

Known, accepted trade-off: changes to the SDK's own runtime (`packages/epilot-sdk-v2/src/*.ts`) or to the generator still don't auto-release. The manual escape hatch is pushing an `@epilot/sdk@x.y.z` tag, which runs the `publish-sdk` job.

## Test plan

Verified the new expression against real main-history commit file lists:

- [x] #464 and #469 (the two missed releases) → trigger
- [x] Spec-update merges #463 and #473 → trigger
- [x] Auto-release commits `a7a5977`, `3ab8f98` → skip (no self-trigger)
- [x] Changeset-only commit `983ef71` and version-packages chore #471 → skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QdG1fUzmCxtQ9Etuya2sks

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdG1fUzmCxtQ9Etuya2sks)_