### PR TITLE
feat(pricing-client): relation types are overridable attributes

### DIFF
--- a/.changeset/pricing-overridable-relations.md
+++ b/.changeset/pricing-overridable-relations.md
@@ -1,0 +1,6 @@
+---
+"@epilot/pricing-client": minor
+"@epilot/sdk": minor
+---
+
+`OVERRIDABLE_ATTRIBUTE_TYPE_LIST` / `OVERRIDABLE_ATTRIBUTE_TYPES` now include the relation types (`relation`, `relation_user`, `relation_address`, `relation_payment_method`): a conditional pricing variant may override a relation attribute by replacing its whole `$relation` list, e.g. to swap a product's prices or a composite price's components. Consumers that gate `overridable_attribute` on this list (Entity API, entity builder) accept the flag on relations once they pick this up.

--- a/clients/pricing-client/src/schema-model.ts
+++ b/clients/pricing-client/src/schema-model.ts
@@ -39,6 +39,10 @@ export const DynamicTariffModeValues = {
  * Entity attribute types a conditional pricing variant may override (`overridable_attribute`).
  * An allowlist, so a new attribute type is never overridable by default. No pricing schema to
  * `satisfies` against — `models.test.ts` checks these against the entity spec.
+ *
+ * Scalars are overridden value for value. The relation types are overridden as a whole: the
+ * variant's `$relation` list replaces the base entity's, which is how a variant swaps a product's
+ * prices or a composite price's components (the entity spec's `RELATION_ATTRIBUTE_TYPE_LIST`).
  */
 export const OVERRIDABLE_ATTRIBUTE_TYPE_LIST = [
   'string',
@@ -53,6 +57,10 @@ export const OVERRIDABLE_ATTRIBUTE_TYPE_LIST = [
   'checkbox',
   'country',
   'tags',
+  'relation',
+  'relation_user',
+  'relation_address',
+  'relation_payment_method',
 ] as const;
 
 /** `string`, not a literal union, so callers can test an unnarrowed `attribute.type`. */

--- a/packages/epilot-sdk-v2/__tests__/models.test.ts
+++ b/packages/epilot-sdk-v2/__tests__/models.test.ts
@@ -102,6 +102,12 @@ describe('runtime models are exposed by the SDK', () => {
     expect(OVERRIDABLE_ATTRIBUTE_TYPES.has('ordered_list')).toBe(false);
   });
 
+  it('every relation type is overridable — a variant swaps the whole $relation list', () => {
+    for (const type of RELATION_ATTRIBUTE_TYPE_LIST) {
+      expect(OVERRIDABLE_ATTRIBUTE_TYPES.has(type), `"${type}" should be overridable`).toBe(true);
+    }
+  });
+
   it('exposes the entity relation affinity enum through @epilot/sdk/entity', () => {
     expect(RelationAffinityMode.WEAK).toBe('weak');
     expect(RelationAffinityMode.STRONG).toBe('strong');

--- a/packages/epilot-sdk-v2/src/models/pricing-model.ts
+++ b/packages/epilot-sdk-v2/src/models/pricing-model.ts
@@ -40,6 +40,10 @@ export const DynamicTariffModeValues = {
  * Entity attribute types a conditional pricing variant may override (`overridable_attribute`).
  * An allowlist, so a new attribute type is never overridable by default. No pricing schema to
  * `satisfies` against — `models.test.ts` checks these against the entity spec.
+ *
+ * Scalars are overridden value for value. The relation types are overridden as a whole: the
+ * variant's `$relation` list replaces the base entity's, which is how a variant swaps a product's
+ * prices or a composite price's components (the entity spec's `RELATION_ATTRIBUTE_TYPE_LIST`).
  */
 export const OVERRIDABLE_ATTRIBUTE_TYPE_LIST = [
   'string',
@@ -54,6 +58,10 @@ export const OVERRIDABLE_ATTRIBUTE_TYPE_LIST = [
   'checkbox',
   'country',
   'tags',
+  'relation',
+  'relation_user',
+  'relation_address',
+  'relation_payment_method',
 ] as const;
 
 /** `string`, not a literal union, so callers can test an unnarrowed `attribute.type`. */


### PR DESCRIPTION
## Summary
- `OVERRIDABLE_ATTRIBUTE_TYPE_LIST` / `OVERRIDABLE_ATTRIBUTE_TYPES` (`@epilot/pricing-client`, re-exported by `@epilot/sdk/pricing`) now include the four relation types: `relation`, `relation_user`, `relation_address`, `relation_payment_method`. A conditional pricing variant overrides a relation as a whole — its `$relation` list replaces the base entity's — which is how a variant swaps a product's prices or a composite price's components. pricing-api's `composeVariant` already treats relations as ordinary overridable attributes; the allowlist that Entity API and the entity builder gate `overridable_attribute` on now agrees.
- The auto-copied `packages/epilot-sdk-v2/src/models/pricing-model.ts` mirrors the change (identical to the client file apart from the import path, as the generator produces it).
- Changeset: minor for `@epilot/pricing-client` and `@epilot/sdk`.

Companion MRs (both work with the currently published SDK by deciding relation eligibility by kind, and get simpler once this ships): entity-api !1705 (validator accepts the flag on relations), epilot360-entity-builder !367 (offers the toggle on relations).

## Test plan
- [x] `packages/epilot-sdk-v2/__tests__/models.test.ts`: new case asserts every `RELATION_ATTRIBUTE_TYPE_LIST` member is overridable; the existing spec-drift check still passes (all members are declared attribute types)
- [x] `biome check` on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01278k3MyryFvCRCMBoftWTm

---
_Generated by [Claude Code](https://claude.ai/code/session_01278k3MyryFvCRCMBoftWTm)_