### PR TITLE
feat: regenerate app-client and customer-portal-client for the custom interval

### DIFF
--- a/clients/app-client/package.json
+++ b/clients/app-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/app-client",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "JavaScript client library for the epilot App API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/app-client/src/openapi-runtime.json
+++ b/clients/app-client/src/openapi-runtime.json
@@ -166,6 +166,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {}
           }
@@ -640,6 +641,7 @@
         }
       },
       "InstallRequest": {
+        "required": true,
         "content": {
           "application/json": {}
         }

--- a/clients/app-client/src/openapi.d.ts
+++ b/clients/app-client/src/openapi.d.ts
@@ -1390,10 +1390,6 @@ declare namespace Components {
                  */
                 key?: string;
             };
-            /**
-             * If set, requests are sent from epilot's static egress IPs. Mutually exclusive with secure_proxy.
-             */
-            use_static_ips?: boolean;
             secure_proxy?: /* If set, requests are routed through the ERP Integration secure proxy. Mutually exclusive with use_static_ips. */ PortalExtensionSecureProxy;
         }
         /**
@@ -1471,7 +1467,7 @@ declare namespace Components {
                 de: string;
             };
             /**
-             * JavaScript code to execute. Must declare a top-level `async function handler(input, context)`. Maximum size: 300KB (hard limit). Security restrictions: eval() and Function() constructor are not allowed.
+             * JavaScript code to execute. Must declare a top-level `async function handler(input, context)`. Maximum size: 300KB (hard limit). Security restrictions: dynamic code evaluation via `eval` or the `Function` constructor is not allowed.
              *
              */
             code: string;
@@ -2030,7 +2026,7 @@ declare namespace Components {
              *         { "id": "ht", "label": { "en": "High tariff" }, "aggregation_group": "consumption", "statistical_method": "sum", "unit": "kWh", "color": "primary", "precision": 2 },
              *         ...
              *       ],
-             *       "intervals": ["PT15M", "PT1H", "P1D", "P1M", "P1Y"],
+             *       "intervals": ["PT15M", "PT1H", "P1D", "P1M", "P1Y", "custom"],
              *       "data_range": { "from": "2024-01-01T00:00:00Z", "to": "2026-05-01T00:00:00Z" }
              *     }
              *   Each type option carries its own `statistical_method`, which describes the method already applied to that type's data and dictates the chart shape: `sum` is rendered as a bar chart; `min`, `average`, and `max` are rendered as a line chart. A single visualization can therefore mix bar-shaped types with line-shaped types. Defaults to `sum` when omitted.
@@ -2271,9 +2267,10 @@ declare namespace Components {
             /**
              * Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.
              * Intervals supported by the API. If omitted, it is assumed that all intervals are supported.
+             * `custom` marks a period-based consumption source: records carry the `period` they cover instead of sitting on a fixed grid, and the portal shows the whole data range as one bar per record.
              *
              */
-            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y")[];
+            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y" | "custom")[];
             auth?: PortalExtensionAuthBlock;
             call: {
                 /**
@@ -2442,9 +2439,10 @@ declare namespace Components {
             /**
              * Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.
              * Intervals supported by the API. If omitted, it is assumed that all intervals are supported.
+             * `custom` marks a period-based consumption source: records carry the `period` they cover instead of sitting on a fixed grid, and the portal shows the whole data range as one bar per record.
              *
              */
-            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y")[];
+            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y" | "custom")[];
             auth?: PortalExtensionAuthBlock;
             call: {
                 /**
@@ -2773,9 +2771,10 @@ declare namespace Components {
             /**
              * Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.
              * Intervals supported by the API. If omitted, it is assumed that all intervals are supported.
+             * `custom` marks a period-based consumption source: records carry the `period` they cover instead of sitting on a fixed grid, and the portal shows the whole data range as one bar per record.
              *
              */
-            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y")[];
+            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y" | "custom")[];
             auth?: PortalExtensionAuthBlock;
             call: {
                 /**
@@ -2907,7 +2906,7 @@ declare namespace Components {
          *         { "id": "ht", "label": { "en": "High tariff" }, "aggregation_group": "consumption", "statistical_method": "sum", "unit": "kWh", "color": "primary", "precision": 2 },
          *         ...
          *       ],
-         *       "intervals": ["PT15M", "PT1H", "P1D", "P1M", "P1Y"],
+         *       "intervals": ["PT15M", "PT1H", "P1D", "P1M", "P1Y", "custom"],
          *       "data_range": { "from": "2024-01-01T00:00:00Z", "to": "2026-05-01T00:00:00Z" }
          *     }
          *   Each type option carries its own `statistical_method`, which describes the method already applied to that type's data and dictates the chart shape: `sum` is rendered as a bar chart; `min`, `average`, and `max` are rendered as a line chart. A single visualization can therefore mix bar-shaped types with line-shaped types. Defaults to `sum` when omitted.

--- a/clients/app-client/src/openapi.json
+++ b/clients/app-client/src/openapi.json
@@ -511,6 +511,7 @@
           }
         ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
@@ -1974,6 +1975,7 @@
         }
       },
       "InstallRequest": {
+        "required": true,
         "content": {
           "application/json": {
             "schema": {
@@ -2254,7 +2256,7 @@
           "code": {
             "type": "string",
             "maxLength": 307200,
-            "description": "JavaScript code to execute. Must declare a top-level `async function handler(input, context)`. Maximum size: 300KB (hard limit). Security restrictions: eval() and Function() constructor are not allowed.\n"
+            "description": "JavaScript code to execute. Must declare a top-level `async function handler(input, context)`. Maximum size: 300KB (hard limit). Security restrictions: dynamic code evaluation via `eval` or the `Function` constructor is not allowed.\n"
           },
           "schedule": {
             "type": "string",
@@ -3417,7 +3419,7 @@
           "intervals": {
             "type": "array",
             "deprecated": true,
-            "description": "Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.\nIntervals supported by the API. If omitted, it is assumed that all intervals are supported.\n",
+            "description": "Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.\nIntervals supported by the API. If omitted, it is assumed that all intervals are supported.\n`custom` marks a period-based consumption source: records carry the `period` they cover instead of sitting on a fixed grid, and the portal shows the whole data range as one bar per record.\n",
             "items": {
               "type": "string",
               "enum": [
@@ -3425,7 +3427,8 @@
                 "PT1H",
                 "P1D",
                 "P1M",
-                "P1Y"
+                "P1Y",
+                "custom"
               ]
             }
           },
@@ -3529,7 +3532,7 @@
           "intervals": {
             "type": "array",
             "deprecated": true,
-            "description": "Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.\nIntervals supported by the API. If omitted, it is assumed that all intervals are supported.\n",
+            "description": "Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.\nIntervals supported by the API. If omitted, it is assumed that all intervals are supported.\n`custom` marks a period-based consumption source: records carry the `period` they cover instead of sitting on a fixed grid, and the portal shows the whole data range as one bar per record.\n",
             "items": {
               "type": "string",
               "enum": [
@@ -3537,7 +3540,8 @@
                 "PT1H",
                 "P1D",
                 "P1M",
-                "P1Y"
+                "P1Y",
+                "custom"
               ]
             }
           },
@@ -3716,7 +3720,7 @@
         "additionalProperties": false
       },
       "PortalExtensionHookVisualizationMetadata": {
-        "description": "Hook that returns runtime metadata describing how a visualization (consumption / price / cost chart) should be rendered for a given portal context (meter, contract, etc). It is invoked by the portal before fetching data, with the same context the data hook would receive, so that the discovery shape can vary per meter/contract. The expected response to the call is:\n  - 200 with a JSON body of shape:\n    {\n      \"type_options\": [\n        { \"id\": \"ht\", \"label\": { \"en\": \"High tariff\" }, \"aggregation_group\": \"consumption\", \"statistical_method\": \"sum\", \"unit\": \"kWh\", \"color\": \"primary\", \"precision\": 2 },\n        ...\n      ],\n      \"intervals\": [\"PT15M\", \"PT1H\", \"P1D\", \"P1M\", \"P1Y\"],\n      \"data_range\": { \"from\": \"2024-01-01T00:00:00Z\", \"to\": \"2026-05-01T00:00:00Z\" }\n    }\n  Each type option carries its own `statistical_method`, which describes the method already applied to that type's data and dictates the chart shape: `sum` is rendered as a bar chart; `min`, `average`, and `max` are rendered as a line chart. A single visualization can therefore mix bar-shaped types with line-shaped types. Defaults to `sum` when omitted.\n  Each type option may also customize its rendering: `color` picks a Spark palette color (`primary`, `slate`, `mauve`, `orange`, `red`, `tomato`, `amber`, `green`, `blue`) used to draw the type's series; `precision` sets the number of decimal places to show for that type's values (axis labels, tooltips, summaries). Both are optional — the consumer falls back to its own defaults when they are omitted.\n  `aggregation_group` controls how types within a group are visually combined (depends on the per-type `statistical_method`):\n    - bar chart (`sum`): same-group types are stacked into a single bar (e.g. ht/nt summed into total consumption); different-group types render side-by-side.\n    - line chart (`min` / `average` / `max`): same-group types are rendered as an area chart; different-group types render as separate lines.\n  All fields are optional; the consumer falls back to its defaults for whatever the hook does not return.\nThe portal looks up this hook implicitly per extension (one `visualizationMetadata` hook per extension) — there is no need for a data-retrieval hook to reference it explicitly.\n",
+        "description": "Hook that returns runtime metadata describing how a visualization (consumption / price / cost chart) should be rendered for a given portal context (meter, contract, etc). It is invoked by the portal before fetching data, with the same context the data hook would receive, so that the discovery shape can vary per meter/contract. The expected response to the call is:\n  - 200 with a JSON body of shape:\n    {\n      \"type_options\": [\n        { \"id\": \"ht\", \"label\": { \"en\": \"High tariff\" }, \"aggregation_group\": \"consumption\", \"statistical_method\": \"sum\", \"unit\": \"kWh\", \"color\": \"primary\", \"precision\": 2 },\n        ...\n      ],\n      \"intervals\": [\"PT15M\", \"PT1H\", \"P1D\", \"P1M\", \"P1Y\", \"custom\"],\n      \"data_range\": { \"from\": \"2024-01-01T00:00:00Z\", \"to\": \"2026-05-01T00:00:00Z\" }\n    }\n  Each type option carries its own `statistical_method`, which describes the method already applied to that type's data and dictates the chart shape: `sum` is rendered as a bar chart; `min`, `average`, and `max` are rendered as a line chart. A single visualization can therefore mix bar-shaped types with line-shaped types. Defaults to `sum` when omitted.\n  Each type option may also customize its rendering: `color` picks a Spark palette color (`primary`, `slate`, `mauve`, `orange`, `red`, `tomato`, `amber`, `green`, `blue`) used to draw the type's series; `precision` sets the number of decimal places to show for that type's values (axis labels, tooltips, summaries). Both are optional — the consumer falls back to its own defaults when they are omitted.\n  `aggregation_group` controls how types within a group are visually combined (depends on the per-type `statistical_method`):\n    - bar chart (`sum`): same-group types are stacked into a single bar (e.g. ht/nt summed into total consumption); different-group types render side-by-side.\n    - line chart (`min` / `average` / `max`): same-group types are rendered as an area chart; different-group types render as separate lines.\n  All fields are optional; the consumer falls back to its defaults for whatever the hook does not return.\nThe portal looks up this hook implicitly per extension (one `visualizationMetadata` hook per extension) — there is no need for a data-retrieval hook to reference it explicitly.\n",
         "type": "object",
         "properties": {
           "id": {
@@ -3833,7 +3837,7 @@
           "intervals": {
             "type": "array",
             "deprecated": true,
-            "description": "Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.\nIntervals supported by the API. If omitted, it is assumed that all intervals are supported.\n",
+            "description": "Deprecated. Prefer declaring a sibling `visualizationMetadata` hook on the same extension and returning `intervals` from its response — that way the supported intervals can vary per meter/contract.\nIntervals supported by the API. If omitted, it is assumed that all intervals are supported.\n`custom` marks a period-based consumption source: records carry the `period` they cover instead of sitting on a fixed grid, and the portal shows the whole data range as one bar per record.\n",
             "items": {
               "type": "string",
               "enum": [
@@ -3841,7 +3845,8 @@
                 "PT1H",
                 "P1D",
                 "P1M",
-                "P1Y"
+                "P1Y",
+                "custom"
               ]
             }
           },
@@ -5275,10 +5280,6 @@
                 "description": "Liquid template for the cache key. Defaults to a hash of org, app, hook, `Input` and `Context`."
               }
             }
-          },
-          "use_static_ips": {
-            "type": "boolean",
-            "description": "If set, requests are sent from epilot's static egress IPs. Mutually exclusive with secure_proxy."
           },
           "secure_proxy": {
             "$ref": "#/components/schemas/PortalExtensionSecureProxy"

--- a/clients/customer-portal-client/package.json
+++ b/clients/customer-portal-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/customer-portal-client",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "API Client for epilot portal API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/customer-portal-client/src/openapi-runtime.json
+++ b/clients/customer-portal-client/src/openapi-runtime.json
@@ -2790,6 +2790,26 @@
           "application/json": {}
         }
       },
+      "TooManyRequests": {
+        "content": {
+          "application/json": {}
+        }
+      },
+      "BadGateway": {
+        "content": {
+          "application/json": {}
+        }
+      },
+      "ServiceUnavailable": {
+        "content": {
+          "application/json": {}
+        }
+      },
+      "GatewayTimeout": {
+        "content": {
+          "application/json": {}
+        }
+      },
       "ConfirmUserInvalidRequest": {
         "content": {
           "application/json": {}

--- a/clients/customer-portal-client/src/openapi.d.ts
+++ b/clients/customer-portal-client/src/openapi.d.ts
@@ -8,6 +8,7 @@ import type {
 
 declare namespace Components {
     namespace Responses {
+        export type BadGateway = Schemas.ErrorResp;
         export interface ConfirmUserInvalidRequest {
             /**
              * Error message
@@ -31,6 +32,7 @@ declare namespace Components {
         }
         export type Forbidden = Schemas.ErrorResp;
         export type ForbiddenByRule = Schemas.ErrorResp | Schemas.FailedRuleErrorResp;
+        export type GatewayTimeout = Schemas.ErrorResp;
         export type InternalServerError = Schemas.ErrorResp;
         export type InvalidRequest = Schemas.ErrorResp;
         export type InvalidRequestCreateMeterReading = {
@@ -46,6 +48,8 @@ declare namespace Components {
             message?: string;
         } | void;
         export type NotFound = Schemas.ErrorResp;
+        export type ServiceUnavailable = Schemas.ErrorResp;
+        export type TooManyRequests = Schemas.ErrorResp;
         export type Unauthorized = Schemas.ErrorResp;
     }
     namespace Schemas {
@@ -933,6 +937,59 @@ declare namespace Components {
              */
             campaign_id?: string;
         }
+        export interface CleverPvContext {
+            /**
+             * Current Clever PV screen identifier
+             */
+            screen?: string;
+            /**
+             * Clever PV application version
+             */
+            version?: string;
+            /**
+             * Device connectivity at the time of the report
+             */
+            connection_state?: string;
+            /**
+             * App locale at the time of the report
+             */
+            locale?: string;
+            /**
+             * App timezone at the time of the report
+             */
+            timezone?: string;
+            /**
+             * Device firmware version when known
+             */
+            firmware_version?: string;
+            /**
+             * App build identifier when known
+             */
+            build?: string;
+            /**
+             * Client-generated correlation id for the report
+             */
+            trace_id?: string;
+            /**
+             * Optional device snapshot from the portal. Attached as a JSON file on
+             * the original Zendesk comment. Must include id when present. Serialized
+             * JSON is limited to 256 KiB.
+             *
+             */
+            device?: {
+                [name: string]: any;
+            };
+            /**
+             * Optional onboarding vendor id and name. Included in the Zendesk
+             * comment. Not a portal entity.
+             *
+             */
+            vendor?: {
+                [name: string]: any;
+                id?: string;
+                name?: string;
+            };
+        }
         export interface CommonConfigAttributes {
             /**
              * Mobile app configuration (top-level; moved out of the config blob).
@@ -1030,6 +1087,14 @@ declare namespace Components {
                  * Enable or disable the new design for the portal
                  */
                 new_design?: boolean;
+                /**
+                 * Enable the MCP (AI agent) connector channel for this portal
+                 */
+                mcp_enabled?: boolean;
+                /**
+                 * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                 */
+                mcp_grant_version?: number;
             };
             /**
              * Access token for the portal
@@ -1565,6 +1630,14 @@ declare namespace Components {
                  * Enable or disable the new design for the portal
                  */
                 new_design?: boolean;
+                /**
+                 * Enable the MCP (AI agent) connector channel for this portal
+                 */
+                mcp_enabled?: boolean;
+                /**
+                 * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                 */
+                mcp_grant_version?: number;
             };
             /**
              * Access token for the portal
@@ -2362,6 +2435,34 @@ declare namespace Components {
              */
             EntitySlug;
         }
+        export interface CreateSupportRequest {
+            report_type: SupportReportType;
+            description: string;
+            /**
+             * Client-generated id for correlating the request
+             */
+            submission_id: string; // ^[A-Za-z0-9._-]+$
+            site_id?: /**
+             * Entity ID
+             * example:
+             * 5da0a718-c822-403d-9f5d-20d4584e0528
+             */
+            EntityId /* uuid */;
+            device_id?: /**
+             * Entity ID
+             * example:
+             * 5da0a718-c822-403d-9f5d-20d4584e0528
+             */
+            EntityId /* uuid */;
+            clever_pv?: CleverPvContext;
+            attachments?: [
+                SupportRequestAttachment?,
+                SupportRequestAttachment?,
+                SupportRequestAttachment?,
+                SupportRequestAttachment?,
+                SupportRequestAttachment?
+            ];
+        }
         export interface CreateUserRequest {
             /**
              * User's email address
@@ -3129,7 +3230,7 @@ declare namespace Components {
                 .../* Per-slug search configuration with scoped targets and templates */ EntitySlugConfig[]
             ];
             /**
-             * Keyword search query
+             * Free-text keyword search. This is plain text, **not** a query language: punctuation separates words rather than carrying any special meaning, and every word has to match. Use `q_fields` to restrict which fields are searched, and `filters`/`targets` for structured filtering. Overly long input is trimmed, and input with no words in it is ignored — the remaining parameters still apply.
              * example:
              * contract
              */
@@ -4966,6 +5067,10 @@ declare namespace Components {
              */
             is_canary?: boolean;
             /**
+             * Whether the portal still runs the old design (the `new_design` feature setting is off). Legacy portals are always served the frozen legacy bundle, even when the org is in canary.
+             */
+            is_legacy_design?: boolean;
+            /**
              * The URL to redirect to
              * example:
              * https://example.com
@@ -6204,6 +6309,14 @@ declare namespace Components {
                  * Enable or disable the new design for the portal
                  */
                 new_design?: boolean;
+                /**
+                 * Enable the MCP (AI agent) connector channel for this portal
+                 */
+                mcp_enabled?: boolean;
+                /**
+                 * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                 */
+                mcp_grant_version?: number;
             };
             /**
              * Access token for the portal
@@ -6832,6 +6945,14 @@ declare namespace Components {
                  * Enable or disable the new design for the portal
                  */
                 new_design?: boolean;
+                /**
+                 * Enable the MCP (AI agent) connector channel for this portal
+                 */
+                mcp_enabled?: boolean;
+                /**
+                 * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                 */
+                mcp_grant_version?: number;
             };
             /**
              * Access token for the portal
@@ -8310,6 +8431,35 @@ declare namespace Components {
             use_case_slug: string;
         }
         export type Source = "ECP" | "ERP" | "360" | "journey-submission";
+        export type SupportReportType = "bug" | "feedback";
+        export interface SupportRequestAttachment {
+            /**
+             * example:
+             * screenshot.png
+             */
+            filename: string;
+            /**
+             * example:
+             * image/png
+             */
+            mime_type: string;
+            /**
+             * Base64-encoded file, optionally as a data URL
+             */
+            contents: string;
+        }
+        export interface SupportRequestResult {
+            /**
+             * example:
+             * 12345
+             */
+            reference: string;
+            /**
+             * example:
+             * new
+             */
+            status: string;
+        }
         /**
          * Optional configuration item that a portal swap can additionally include. The swap always transfers the pages and the functional experience config that keep the portal working. These items are opt-in on top of that and are OFF by default. Domain and access/security settings (domain, cognito_details, auth_settings) can never be swapped and are therefore not part of this enum.
          */
@@ -8612,6 +8762,14 @@ declare namespace Components {
                  * Enable or disable the new design for the portal
                  */
                 new_design?: boolean;
+                /**
+                 * Enable the MCP (AI agent) connector channel for this portal
+                 */
+                mcp_enabled?: boolean;
+                /**
+                 * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                 */
+                mcp_grant_version?: number;
             };
             /**
              * Access token for the portal
@@ -9208,6 +9366,14 @@ declare namespace Components {
                  * Enable or disable the new design for the portal
                  */
                 new_design?: boolean;
+                /**
+                 * Enable the MCP (AI agent) connector channel for this portal
+                 */
+                mcp_enabled?: boolean;
+                /**
+                 * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                 */
+                mcp_grant_version?: number;
             };
             /**
              * Access token for the portal
@@ -9700,9 +9866,10 @@ declare namespace Components {
              */
             type_options?: VisualizationTypeOption[];
             /**
-             * Intervals supported for the current context. If omitted, all intervals are assumed supported.
+             * Intervals supported for the current context. If omitted, all intervals are assumed supported. `custom` marks a period-based consumption source: the portal requests the whole `data_range` once with `interval=custom` and renders one bar per returned record (see `period` on the consumption data point) instead of offering interval / date navigation or period comparison. When `custom` is present it takes precedence over any fixed intervals also listed.
+             *
              */
-            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y")[];
+            intervals?: ("PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y" | "custom")[];
             data_range?: /* Earliest / latest timestamps for which data is available in the current context. */ VisualizationDataRange;
         }
         export interface VisualizationTypeOption {
@@ -10273,7 +10440,11 @@ declare namespace Paths {
              */
             columns: /* One column of the portal data export CSV. */ Components.Schemas.PortalDataExportColumn[];
             expand_over?: string;
-            language?: "de" | "en";
+            /**
+             * example:
+             * de
+             */
+            language?: string;
         }
         namespace Responses {
             export interface $202 {
@@ -11393,7 +11564,7 @@ declare namespace Paths {
             export type ExtensionId = string;
             export type From = string; // date-time
             export type HookId = string;
-            export type Interval = "PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y";
+            export type Interval = "PT15M" | "PT1H" | "P1D" | "P1M" | "P1Y" | "custom";
             export type MeterId = string;
             export type To = string; // date-time
         }
@@ -11441,6 +11612,26 @@ declare namespace Paths {
                      */
                     label?: {
                         [name: string]: string;
+                    };
+                    /**
+                     * The date range this value covers. Required for period-based sources (`interval=custom`), whose records don't sit on a fixed time grid: the portal renders one bar per record, orders them by `period.from`, and — unless `label` is set — labels each bar with the formatted `from` - `to` range. Ignored for interval-based retrieval.
+                     *
+                     * example:
+                     * {
+                     *   "from": "2024-01-03T00:00:00.000Z",
+                     *   "to": "2025-01-05T00:00:00.000Z"
+                     * }
+                     */
+                    period?: {
+                        /**
+                         * Start of the covered period.
+                         */
+                        from: string; // date-time
+                        /**
+                         * End of the covered period. Shown as given in the fallback label, so pass the date the period visibly ends on (consecutive periods may share this boundary).
+                         *
+                         */
+                        to: string; // date-time
                     };
                 }[];
             }
@@ -13163,6 +13354,14 @@ declare namespace Paths {
                      * Enable or disable the new design for the portal
                      */
                     new_design?: boolean;
+                    /**
+                     * Enable the MCP (AI agent) connector channel for this portal
+                     */
+                    mcp_enabled?: boolean;
+                    /**
+                     * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                     */
+                    mcp_grant_version?: number;
                 };
                 /**
                  * Access token for the portal
@@ -13789,6 +13988,14 @@ declare namespace Paths {
                      * Enable or disable the new design for the portal
                      */
                     new_design?: boolean;
+                    /**
+                     * Enable the MCP (AI agent) connector channel for this portal
+                     */
+                    mcp_enabled?: boolean;
+                    /**
+                     * Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled
+                     */
+                    mcp_grant_version?: number;
                 };
                 /**
                  * Access token for the portal
@@ -21192,6 +21399,7 @@ export type BlockRequest = Components.Schemas.BlockRequest;
 export type BlockType = Components.Schemas.BlockType;
 export type BusinessPartnerItem = Components.Schemas.BusinessPartnerItem;
 export type CampaignWidget = Components.Schemas.CampaignWidget;
+export type CleverPvContext = Components.Schemas.CleverPvContext;
 export type CommonConfigAttributes = Components.Schemas.CommonConfigAttributes;
 export type CommonConfigAttributesV3 = Components.Schemas.CommonConfigAttributesV3;
 export type Contact = Components.Schemas.Contact;
@@ -21202,6 +21410,7 @@ export type ContextEntities = Components.Schemas.ContextEntities;
 export type ContextEntity = Components.Schemas.ContextEntity;
 export type Contract = Components.Schemas.Contract;
 export type ContractIdentifier = Components.Schemas.ContractIdentifier;
+export type CreateSupportRequest = Components.Schemas.CreateSupportRequest;
 export type CreateUserRequest = Components.Schemas.CreateUserRequest;
 export type Currency = Components.Schemas.Currency;
 export type DataRetrievalItem = Components.Schemas.DataRetrievalItem;
@@ -21323,6 +21532,9 @@ export type Schema = Components.Schemas.Schema;
 export type SearchIncludes = Components.Schemas.SearchIncludes;
 export type SecureProxyConfig = Components.Schemas.SecureProxyConfig;
 export type Source = Components.Schemas.Source;
+export type SupportReportType = Components.Schemas.SupportReportType;
+export type SupportRequestAttachment = Components.Schemas.SupportRequestAttachment;
+export type SupportRequestResult = Components.Schemas.SupportRequestResult;
 export type SwappableConfig = Components.Schemas.SwappableConfig;
 export type TariffType = Components.Schemas.TariffType;
 export type TeaserWidget = Components.Schemas.TeaserWidget;

--- a/clients/customer-portal-client/src/openapi.json
+++ b/clients/customer-portal-client/src/openapi.json
@@ -543,10 +543,7 @@
                   },
                   "language": {
                     "type": "string",
-                    "enum": [
-                      "de",
-                      "en"
-                    ]
+                    "example": "de"
                   }
                 }
               }
@@ -962,11 +959,12 @@
                 "PT1H",
                 "P1D",
                 "P1M",
-                "P1Y"
+                "P1Y",
+                "custom"
               ]
             },
             "required": true,
-            "description": "Interval between consumption data points (e.g., PT15M for 15 minutes, PT1H for hourly). Not all intervals have to be supported."
+            "description": "Interval between consumption data points (e.g., PT15M for 15 minutes, PT1H for hourly). Not all intervals have to be supported. `custom` is period-based retrieval for sources that advertise it in their `visualizationMetadata.intervals`: the App returns one record per period it has data for within `from`..`to`, each carrying `period`, and the portal renders every record as its own bar.\n"
           },
           {
             "in": "query",
@@ -1019,6 +1017,30 @@
                             "example": {
                               "en": "Billing period 1",
                               "de": "Abrechnungszeitraum 1"
+                            }
+                          },
+                          "period": {
+                            "type": "object",
+                            "description": "The date range this value covers. Required for period-based sources (`interval=custom`), whose records don't sit on a fixed time grid: the portal renders one bar per record, orders them by `period.from`, and — unless `label` is set — labels each bar with the formatted `from` - `to` range. Ignored for interval-based retrieval.\n",
+                            "properties": {
+                              "from": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Start of the covered period."
+                              },
+                              "to": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "End of the covered period. Shown as given in the fallback label, so pass the date the period visibly ends on (consecutive periods may share this boundary).\n"
+                              }
+                            },
+                            "required": [
+                              "from",
+                              "to"
+                            ],
+                            "example": {
+                              "from": "2024-01-03T00:00:00.000Z",
+                              "to": "2025-01-05T00:00:00.000Z"
                             }
                           }
                         },
@@ -11537,6 +11559,46 @@
           }
         }
       },
+      "TooManyRequests": {
+        "description": "The upstream service rate-limited the request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResp"
+            }
+          }
+        }
+      },
+      "BadGateway": {
+        "description": "The upstream service failed to process the request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResp"
+            }
+          }
+        }
+      },
+      "ServiceUnavailable": {
+        "description": "The requested feature is not configured",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResp"
+            }
+          }
+        }
+      },
+      "GatewayTimeout": {
+        "description": "The upstream service timed out",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResp"
+            }
+          }
+        }
+      },
       "ConfirmUserInvalidRequest": {
         "description": "The request could not be validated",
         "content": {
@@ -12571,6 +12633,17 @@
               "new_design": {
                 "type": "boolean",
                 "description": "Enable or disable the new design for the portal"
+              },
+              "mcp_enabled": {
+                "type": "boolean",
+                "description": "Enable the MCP (AI agent) connector channel for this portal"
+              },
+              "mcp_grant_version": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "readOnly": true,
+                "description": "Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled"
               }
             }
           },
@@ -15959,7 +16032,7 @@
           },
           "q": {
             "type": "string",
-            "description": "Keyword search query",
+            "description": "Free-text keyword search. This is plain text, **not** a query language: punctuation separates words rather than carrying any special meaning, and every word has to match. Use `q_fields` to restrict which fields are searched, and `filters`/`targets` for structured filtering. Overly long input is trimmed, and input with no words in it is ignored — the remaining parameters still apply.",
             "example": "contract"
           },
           "q_fields": {
@@ -16597,7 +16670,7 @@
           },
           "intervals": {
             "type": "array",
-            "description": "Intervals supported for the current context. If omitted, all intervals are assumed supported.",
+            "description": "Intervals supported for the current context. If omitted, all intervals are assumed supported. `custom` marks a period-based consumption source: the portal requests the whole `data_range` once with `interval=custom` and renders one bar per returned record (see `period` on the consumption data point) instead of offering interval / date navigation or period comparison. When `custom` is present it takes precedence over any fixed intervals also listed.\n",
             "items": {
               "type": "string",
               "enum": [
@@ -16605,7 +16678,8 @@
                 "PT1H",
                 "P1D",
                 "P1M",
-                "P1Y"
+                "P1Y",
+                "custom"
               ]
             }
           },
@@ -19219,6 +19293,17 @@
               "new_design": {
                 "type": "boolean",
                 "description": "Enable or disable the new design for the portal"
+              },
+              "mcp_enabled": {
+                "type": "boolean",
+                "description": "Enable the MCP (AI agent) connector channel for this portal"
+              },
+              "mcp_grant_version": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 0,
+                "readOnly": true,
+                "description": "Server-managed generation used to invalidate MCP grants after the connector is disabled or re-enabled"
               }
             }
           },
@@ -19877,6 +19962,10 @@
             "type": "boolean",
             "description": "Whether the org is in canary mode"
           },
+          "is_legacy_design": {
+            "type": "boolean",
+            "description": "Whether the portal still runs the old design (the `new_design` feature setting is off). Legacy portals are always served the frozen legacy bundle, even when the org is in canary."
+          },
           "redirect_to": {
             "type": "string",
             "description": "The URL to redirect to",
@@ -19932,6 +20021,157 @@
           "access_status": {
             "type": "boolean",
             "example": true
+          }
+        }
+      },
+      "SupportReportType": {
+        "type": "string",
+        "enum": [
+          "bug",
+          "feedback"
+        ]
+      },
+      "SupportRequestAttachment": {
+        "type": "object",
+        "required": [
+          "filename",
+          "mime_type",
+          "contents"
+        ],
+        "properties": {
+          "filename": {
+            "type": "string",
+            "maxLength": 255,
+            "example": "screenshot.png"
+          },
+          "mime_type": {
+            "type": "string",
+            "example": "image/png"
+          },
+          "contents": {
+            "type": "string",
+            "description": "Base64-encoded file, optionally as a data URL"
+          }
+        }
+      },
+      "CleverPvContext": {
+        "type": "object",
+        "properties": {
+          "screen": {
+            "type": "string",
+            "maxLength": 256,
+            "description": "Current Clever PV screen identifier"
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Clever PV application version"
+          },
+          "connection_state": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Device connectivity at the time of the report"
+          },
+          "locale": {
+            "type": "string",
+            "maxLength": 32,
+            "description": "App locale at the time of the report"
+          },
+          "timezone": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "App timezone at the time of the report"
+          },
+          "firmware_version": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "Device firmware version when known"
+          },
+          "build": {
+            "type": "string",
+            "maxLength": 64,
+            "description": "App build identifier when known"
+          },
+          "trace_id": {
+            "type": "string",
+            "maxLength": 128,
+            "description": "Client-generated correlation id for the report"
+          },
+          "device": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Optional device snapshot from the portal. Attached as a JSON file on\nthe original Zendesk comment. Must include id when present. Serialized\nJSON is limited to 256 KiB.\n"
+          },
+          "vendor": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "description": "Optional onboarding vendor id and name. Included in the Zendesk\ncomment. Not a portal entity.\n"
+          }
+        }
+      },
+      "CreateSupportRequest": {
+        "type": "object",
+        "required": [
+          "report_type",
+          "description",
+          "submission_id"
+        ],
+        "properties": {
+          "report_type": {
+            "$ref": "#/components/schemas/SupportReportType"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 8000
+          },
+          "submission_id": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 128,
+            "pattern": "^[A-Za-z0-9._-]+$",
+            "description": "Client-generated id for correlating the request"
+          },
+          "site_id": {
+            "$ref": "#/components/schemas/EntityId"
+          },
+          "device_id": {
+            "$ref": "#/components/schemas/EntityId"
+          },
+          "clever_pv": {
+            "$ref": "#/components/schemas/CleverPvContext"
+          },
+          "attachments": {
+            "type": "array",
+            "maxItems": 5,
+            "items": {
+              "$ref": "#/components/schemas/SupportRequestAttachment"
+            }
+          }
+        }
+      },
+      "SupportRequestResult": {
+        "type": "object",
+        "required": [
+          "reference",
+          "status"
+        ],
+        "properties": {
+          "reference": {
+            "type": "string",
+            "example": "12345"
+          },
+          "status": {
+            "type": "string",
+            "example": "new"
           }
         }
       }


### PR DESCRIPTION
## Summary
Regenerates both clients touched by the period-based consumption contract, from the specs as merged on their `main` branches:

- **`@epilot/app-client` → 0.17.0** (app-api!91): portal extension hook `intervals` enums accept `custom`, marking a period-based consumption source whose records carry the `period` they cover instead of sitting on a fixed grid. Also picks up the spec-only changes that landed on app-api since the last regen (a schema dropped `use_static_ips`; reworded `eval` note).
- **`@epilot/customer-portal-client` → 0.45.0** (customer-portal-api!1513): `GET /v2/portal/consumption` `interval` and `VisualizationMetadata.intervals` accept `custom`; consumption data points gain an optional `period: { from, to }`. Also picks up the other contract changes that landed on customer-portal-api since the last regen (additional error responses, `CleverPvContext`).

Versions bumped in the client `package.json`s; no changeset (publishing handled manually from the packed tarballs).

## Test plan
- [x] `openapi.json` / `openapi-runtime.json` / `openapi.d.ts` regenerated via `scripts/update-openapi.js` + `openapicmd typegen` — nothing hand-edited
- [x] Both clients build (`pnpm run build`) and pack
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ud4GPLxfL8mSWG7FGNibzp