### PR TITLE
feat(integration-toolkit-client): publish the monitoring code catalog

### DIFF
--- a/clients/integration-toolkit-client/package.json
+++ b/clients/integration-toolkit-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/integration-toolkit-client",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Client library for epilot Integration Toolkit API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -28,6 +28,7 @@
     "bundle-definition": "webpack",
     "openapi": "node ../../scripts/update-openapi.js https://docs.api.epilot.io/integration-toolkit.yaml",
     "openapi:local": "node ../../scripts/update-openapi.js ../../../erp-integration-api/lambda/ApiHandlerFunction/openapi.yml",
+    "codes:local": "node scripts/update-codes.js",
     "typegen": "openapi typegen src/openapi.json --client > src/openapi.d.ts",
     "build": "tsc && npm run build:patch && npm run bundle-definition",
     "build:patch": "sed -i'' -e '/^__exportStar.*openapi.*$/d' dist/index.js",

--- a/clients/integration-toolkit-client/scripts/update-codes.js
+++ b/clients/integration-toolkit-client/scripts/update-codes.js
@@ -34,10 +34,7 @@ const family = snapshot.families[0];
 const quote = (s) => `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
 
 const entries = codes
-  .map(
-    (c) =>
-      `  ${c.code}: { level: ${quote(c.level)}, description: ${quote(c.description)} },`,
-  )
+  .map((c) => `  ${c.code}: { level: ${quote(c.level)}, description: ${quote(c.description)} },`)
   .join('\n');
 
 const out = `/* eslint-disable */
@@ -110,15 +107,11 @@ fs.writeFileSync(OUT, out);
 // Format the generated file with the repo's formatter, so `codes:local` always leaves
 // the tree lint-clean and a regeneration never shows up as a formatting diff.
 try {
-  require('node:child_process').execFileSync(
-    'npx',
-    ['biome', 'check', '--write', path.relative(process.cwd(), OUT)],
-    { stdio: 'ignore' },
-  );
+  require('node:child_process').execFileSync('npx', ['biome', 'check', '--write', path.relative(process.cwd(), OUT)], {
+    stdio: 'ignore',
+  });
 } catch {
   console.warn('biome formatting skipped (run `npm run lint` to check)');
 }
 
-console.log(
-  `Wrote ${path.relative(process.cwd(), OUT)} — ${codes.length} codes + the ${family.pattern} family`,
-);
+console.log(`Wrote ${path.relative(process.cwd(), OUT)} — ${codes.length} codes + the ${family.pattern} family`);

--- a/clients/integration-toolkit-client/scripts/update-codes.js
+++ b/clients/integration-toolkit-client/scripts/update-codes.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * Generates src/codes.ts — the monitoring code catalog — from the snapshot
+ * erp-integration-api emits.
+ *
+ * The descriptions and levels are owned by the producer
+ * (packages/erp-utils/src/monitoring/code-catalog.ts), where a code without a
+ * description is a compile error and the snapshot is asserted in CI. This script
+ * turns that artifact into a published module, so the integration hub and any other
+ * consumer import the catalog instead of hand-copying it — which is what let a
+ * frontend become the source of truth for a backend taxonomy in the first place.
+ *
+ * The code UNION type is not defined here: it comes from the OpenAPI spec as
+ * `Components.Schemas.MonitoringCode` and is re-exported by src/codes.ts, so there is
+ * exactly one definition of the list.
+ *
+ * Usage: npm run codes:local
+ * Assumes erp-integration-api is checked out at ../../../erp-integration-api.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SNAPSHOT = path.resolve(
+  __dirname,
+  '../../../../erp-integration-api/packages/erp-utils/src/monitoring/__snapshots__/monitoring-codes.json',
+);
+const OUT = path.resolve(__dirname, '../src/codes.ts');
+
+const snapshot = JSON.parse(fs.readFileSync(SNAPSHOT, 'utf8'));
+const codes = [...snapshot.codes].sort((a, b) => a.code.localeCompare(b.code));
+const family = snapshot.families[0];
+
+const quote = (s) => `'${s.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+
+const entries = codes
+  .map(
+    (c) =>
+      `  ${c.code}: { level: ${quote(c.level)}, description: ${quote(c.description)} },`,
+  )
+  .join('\n');
+
+const out = `/* eslint-disable */
+/**
+ * DO NOT MODIFY - GENERATED FROM erp-integration-api
+ *
+ * Monitoring code catalog: the level and operator-facing description for every code
+ * the Integration Toolkit emits. Regenerate with \`npm run codes:local\`.
+ */
+
+import type { Components } from './openapi';
+
+/**
+ * Every monitoring code the toolkit itself emits.
+ *
+ * Local alias only — the public \`MonitoringCode\` type is exported from './openapi',
+ * generated from the spec's enum. Re-exporting it here would collide with that.
+ */
+type MonitoringCode = Components.Schemas.MonitoringCode;
+
+/** The level a code is always emitted at. */
+export type MonitoringCodeLevel = 'success' | 'error' | 'warning' | 'info';
+
+export interface MonitoringCodeMeta {
+  level: MonitoringCodeLevel;
+  description: string;
+}
+
+/**
+ * Upstream HTTP statuses are emitted as a family rather than as taxonomy members,
+ * because the status is unbounded. They are emitted at \`warning\`.
+ */
+export const HTTP_STATUS_CODE_FAMILY = {
+  pattern: ${quote(family.pattern)},
+  level: ${quote(family.level)} as MonitoringCodeLevel,
+  description: ${quote(family.description)},
+} as const;
+
+const HTTP_STATUS_CODE_PATTERN = /^HTTP_\\d{3}$/;
+
+/** Level and description per taxonomy code. */
+export const MONITORING_CODES: Record<MonitoringCode, MonitoringCodeMeta> = {
+${entries}
+};
+
+/**
+ * Describes any code seen on a monitoring event, including the \`HTTP_{status}\`
+ * family and codes this package predates. Returns \`undefined\` only for a code it
+ * cannot place at all, so callers can render a sensible fallback.
+ */
+export function describeMonitoringCode(
+  code: string,
+): MonitoringCodeMeta | undefined {
+  const known = (MONITORING_CODES as Record<string, MonitoringCodeMeta>)[code];
+  if (known) return known;
+
+  if (HTTP_STATUS_CODE_PATTERN.test(code)) {
+    return {
+      level: HTTP_STATUS_CODE_FAMILY.level,
+      description: HTTP_STATUS_CODE_FAMILY.description,
+    };
+  }
+
+  return undefined;
+}
+`;
+
+fs.writeFileSync(OUT, out);
+
+// Format the generated file with the repo's formatter, so `codes:local` always leaves
+// the tree lint-clean and a regeneration never shows up as a formatting diff.
+try {
+  require('node:child_process').execFileSync(
+    'npx',
+    ['biome', 'check', '--write', path.relative(process.cwd(), OUT)],
+    { stdio: 'ignore' },
+  );
+} catch {
+  console.warn('biome formatting skipped (run `npm run lint` to check)');
+}
+
+console.log(
+  `Wrote ${path.relative(process.cwd(), OUT)} — ${codes.length} codes + the ${family.pattern} family`,
+);

--- a/clients/integration-toolkit-client/src/codes.test.ts
+++ b/clients/integration-toolkit-client/src/codes.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { HTTP_STATUS_CODE_FAMILY, MONITORING_CODES, describeMonitoringCode } from './codes';
+import openapi from './openapi.json';
+
+/**
+ * The catalog is generated from erp-integration-api's snapshot, while the code union
+ * comes from the spec's `MonitoringCode` enum. They are refreshed by two different
+ * commands (`codes:local` and `openapi:local`), so running only one of them is the
+ * realistic way this package ships an inconsistent pair. These tests catch that.
+ */
+describe('monitoring code catalog', () => {
+  const specCodes: string[] = (
+    openapi as never as {
+      components: { schemas: { MonitoringCode: { enum: string[] } } };
+    }
+  ).components.schemas.MonitoringCode.enum;
+
+  it('covers exactly the codes in the spec enum', () => {
+    expect(Object.keys(MONITORING_CODES).sort()).toEqual([...specCodes].sort());
+  });
+
+  it('gives every code a level and a non-empty description', () => {
+    for (const [code, meta] of Object.entries(MONITORING_CODES)) {
+      expect(meta.level, code).toMatch(/^(success|error|warning|info)$/);
+      expect(meta.description.trim(), code).not.toBe('');
+    }
+  });
+
+  it('describes a known code', () => {
+    expect(describeMonitoringCode('ENTITY_CREATED')?.level).toBe('success');
+    expect(describeMonitoringCode('ACK_TIMEOUT')?.level).toBe('warning');
+  });
+
+  it('describes the HTTP_{status} family, which is not in the enum', () => {
+    expect(specCodes).not.toContain('HTTP_502');
+    expect(describeMonitoringCode('HTTP_502')).toEqual({
+      level: HTTP_STATUS_CODE_FAMILY.level,
+      description: HTTP_STATUS_CODE_FAMILY.description,
+    });
+  });
+
+  it('returns undefined for a code it cannot place, so callers can fall back', () => {
+    expect(describeMonitoringCode('SOMETHING_FROM_THE_FUTURE')).toBeUndefined();
+    expect(describeMonitoringCode('HTTP_50')).toBeUndefined();
+  });
+});

--- a/clients/integration-toolkit-client/src/codes.ts
+++ b/clients/integration-toolkit-client/src/codes.ts
@@ -1,0 +1,268 @@
+/* eslint-disable */
+/**
+ * DO NOT MODIFY - GENERATED FROM erp-integration-api
+ *
+ * Monitoring code catalog: the level and operator-facing description for every code
+ * the Integration Toolkit emits. Regenerate with `npm run codes:local`.
+ */
+
+import type { Components } from './openapi';
+
+/**
+ * Every monitoring code the toolkit itself emits.
+ *
+ * Local alias only — the public `MonitoringCode` type is exported from './openapi',
+ * generated from the spec's enum. Re-exporting it here would collide with that.
+ */
+type MonitoringCode = Components.Schemas.MonitoringCode;
+
+/** The level a code is always emitted at. */
+export type MonitoringCodeLevel = 'success' | 'error' | 'warning' | 'info';
+
+export interface MonitoringCodeMeta {
+  level: MonitoringCodeLevel;
+  description: string;
+}
+
+/**
+ * Upstream HTTP statuses are emitted as a family rather than as taxonomy members,
+ * because the status is unbounded. They are emitted at `warning`.
+ */
+export const HTTP_STATUS_CODE_FAMILY = {
+  pattern: 'HTTP_{status}',
+  level: 'warning' as MonitoringCodeLevel,
+  description:
+    'The upstream system answered the proxied request with this HTTP status. The proxy itself worked — it reached the target and returned its answer — so the refusal is recorded against the use case that owns the request.',
+} as const;
+
+const HTTP_STATUS_CODE_PATTERN = /^HTTP_\d{3}$/;
+
+/** Level and description per taxonomy code. */
+export const MONITORING_CODES: Record<MonitoringCode, MonitoringCodeMeta> = {
+  ACK_CONFIRMED: { level: 'info', description: 'Acknowledgement was confirmed by the ERP system' },
+  ACK_PENDING: { level: 'info', description: 'Acknowledgement is pending from the ERP system' },
+  ACK_TIMEOUT: { level: 'warning', description: 'Acknowledgement timed out waiting for the ERP system' },
+  ATTACHMENT_NOT_FOUND: {
+    level: 'error',
+    description: 'The file no longer exists — it was removed between the event and the delivery',
+  },
+  ATTRIBUTE_TYPE_MISMATCH: {
+    level: 'error',
+    description: 'An attribute value did not match the type declared in the entity schema',
+  },
+  DEPRECATED_ENDPOINT: { level: 'error', description: 'This endpoint version is deprecated' },
+  DIRECT_ENTITY_NOT_ALLOWED: {
+    level: 'error',
+    description: 'The entity is not permitted by the use case entity allowlist',
+  },
+  DIRECT_PAYLOAD_INVALID: {
+    level: 'error',
+    description: 'The direct mode payload failed validation against the versioned payload schema',
+  },
+  DIRECT_VERSION_UNSUPPORTED: {
+    level: 'error',
+    description: 'The direct mode payload version is not supported by the platform',
+  },
+  DUPLICATE_EVENT: { level: 'info', description: 'This event was already processed (duplicate)' },
+  ENTITY_CREATED: { level: 'success', description: 'A new entity was created in epilot' },
+  ENTITY_DELETED: { level: 'success', description: 'An entity was deleted from epilot' },
+  ENTITY_NO_OP: { level: 'success', description: 'No changes were needed for the entity' },
+  ENTITY_REFERENCE_NOT_FOUND: {
+    level: 'error',
+    description: 'A direct-by-id entity reference points at an entity that does not exist or has a different schema',
+  },
+  ENTITY_UPDATED: { level: 'success', description: 'An existing entity was updated in epilot' },
+  EVENT_NOT_CONFIGURED: { level: 'error', description: 'No mapping configuration found for this event type' },
+  EXTERNAL_API_ERROR: { level: 'error', description: 'An external API returned an error' },
+  EXTERNAL_ERROR: {
+    level: 'error',
+    description:
+      "An error span pushed by an external system (e.g. your integration middleware) via the external monitoring events endpoint. epilot assigns the code from the span's level; the middleware never sends one.",
+  },
+  EXTERNAL_INFO: {
+    level: 'info',
+    description: 'An informational span pushed by an external system via the external monitoring events endpoint.',
+  },
+  EXTERNAL_SUCCESS: {
+    level: 'success',
+    description: 'A success span pushed by an external system via the external monitoring events endpoint.',
+  },
+  EXTERNAL_WARNING: {
+    level: 'warning',
+    description: 'A warning span pushed by an external system via the external monitoring events endpoint.',
+  },
+  FAN_OUT_EMPTY: {
+    level: 'info',
+    description:
+      'The split expression returned an empty list, so nothing was sent — expected for events that carry no relevant items',
+  },
+  FAN_OUT_INVALID_RESULT: {
+    level: 'error',
+    description:
+      'The split expression returned something other than a list, so no deliveries could be created — see split_expression_result_type',
+  },
+  FILE_EXTRACTION_FAILED: { level: 'error', description: 'Failed to extract file from the request' },
+  FILE_FETCH_FAILED: {
+    level: 'error',
+    description: 'The file could not be fetched from epilot before it could be uploaded',
+  },
+  FILE_PROXY_OK: { level: 'success', description: 'File proxy request completed successfully' },
+  FILE_PROXY_UPLOAD_ENQUEUED: {
+    level: 'info',
+    description: 'A per-file upload was accepted for delivery during fan-out',
+  },
+  FILE_PROXY_UPLOAD_FAILED: {
+    level: 'error',
+    description: 'A file upload failed terminally, or every delivery attempt was exhausted',
+  },
+  FILE_PROXY_UPLOAD_RETRYING: {
+    level: 'warning',
+    description:
+      'A file upload failed with a retryable error and will be retried automatically — one event per attempt',
+  },
+  FILE_PROXY_UPLOADED: { level: 'success', description: 'The external system accepted the file' },
+  FILE_TOO_LARGE: {
+    level: 'error',
+    description: 'The file exceeds the maximum size configured on the upload use case',
+  },
+  INTEGRATION_NOT_FOUND: {
+    level: 'error',
+    description:
+      "The inbound event referenced an integration_id that does not exist in the calling token's organization. Check the integration id and that the token belongs to the same org.",
+  },
+  INVALID_METER_READING_ATTRIBUTES: { level: 'error', description: 'Meter reading has invalid attributes' },
+  LOOKUP_UNMAPPED: {
+    level: 'warning',
+    description:
+      'A value was not listed in a lookup table and its fallback was used — see lookup_name and lookup_key for the gap',
+  },
+  MALFORMED_PAYLOAD: { level: 'error', description: 'The event payload could not be parsed (malformed JSON)' },
+  MAPPING_EXPRESSION_FAILED: { level: 'error', description: 'A mapping expression failed to evaluate' },
+  METER_READING_DELETED: {
+    level: 'success',
+    description:
+      'One or more meter readings were deleted — emitted once per batch, not per reading (reading_count and external_ids in details)',
+  },
+  METER_READING_GROUP_FAILED: {
+    level: 'error',
+    description:
+      'A batch write of meter readings failed permanently after all retries — summary event alongside the per-reading errors',
+  },
+  METER_READING_GROUP_RETRYING: {
+    level: 'error',
+    description:
+      'A batch write of meter readings failed and will be retried automatically — one event per attempt covering the whole group (reading_count and external_ids in details)',
+  },
+  METER_READING_UPSERTED: {
+    level: 'success',
+    description:
+      'One or more meter readings were created or updated — emitted once per batch, not per reading (reading_count and external_ids in details)',
+  },
+  METERING_API_ERROR: { level: 'error', description: 'The metering API returned an error' },
+  MISSING_REQUIRED_PARAM: { level: 'error', description: 'A required parameter is missing from the request' },
+  MISSING_UNIQUE_IDENTIFIERS: {
+    level: 'error',
+    description: 'The event is missing the unique identifier field(s) required to match an entity',
+  },
+  MSG_ACKED: {
+    level: 'info',
+    description: 'Outbound message acknowledged by the polling consumer and removed from the queue',
+  },
+  MSG_DEAD_LETTERED: {
+    level: 'info',
+    description:
+      'Outbound message moved to the dead-letter queue after exhausting delivery attempts, or via an operator skip',
+  },
+  MSG_ENQUEUED: {
+    level: 'info',
+    description: 'Outbound message enqueued to the poll queue, awaiting consumption by the ERP',
+  },
+  MSG_EXPIRED_UNPOLLED: {
+    level: 'info',
+    description: 'Outbound message expired before being consumed — retention elapsed without a successful poll',
+  },
+  MSG_HEAD_BLOCKED: {
+    level: 'info',
+    description:
+      'Outbound stream halted by a poison head message (block policy) — requires operator unblock or consumer acknowledgement',
+  },
+  OAUTH2_TOKEN_FAILURE: { level: 'error', description: 'Failed to obtain an OAuth2 access token' },
+  PAYLOAD_TOO_LARGE: {
+    level: 'error',
+    description: 'The payload exceeded the maximum size accepted by the receiving system',
+  },
+  PRUNE_SCOPE_COMPLETED: { level: 'success', description: 'Scope pruning completed successfully' },
+  PRUNE_SCOPE_PARTIAL_FAILURE: { level: 'error', description: 'Scope pruning completed with some failures' },
+  RECURSION_DEPTH_EXCEEDED: { level: 'error', description: 'Maximum recursion depth was exceeded during processing' },
+  RELATION_REF_ITEM_NOT_FOUND: {
+    level: 'error',
+    description:
+      'The relation_ref target entity exists but the referenced item/value could not be matched — skipped as non-retryable. Check the mapping configuration and the entity data.',
+  },
+  RELATION_REF_VALUE_UNDEFINED: {
+    level: 'error',
+    description: 'A relation_ref mapping value resolved to undefined — check the mapping expression',
+  },
+  REQUIRED_PARAM_MISSING: {
+    level: 'error',
+    description:
+      'A param the use case marks as required resolved to nothing, so the delivery was stopped before anything was sent — see param_name',
+  },
+  SECURE_PROXY_DISABLED: { level: 'error', description: 'The secure proxy use case is disabled' },
+  SECURE_PROXY_DOMAIN_BLOCKED: { level: 'error', description: 'The target domain is blocked' },
+  SECURE_PROXY_DOMAIN_NOT_ALLOWED: { level: 'error', description: 'The target domain is not in the allowlist' },
+  SECURE_PROXY_ERROR: { level: 'error', description: 'An error occurred in the secure proxy' },
+  SECURE_PROXY_INVALID_CONFIG: { level: 'error', description: 'The secure proxy configuration is invalid' },
+  SECURE_PROXY_INVALID_TYPE: { level: 'error', description: 'The secure proxy type is invalid' },
+  SECURE_PROXY_INVALID_URL: { level: 'error', description: 'The target URL is invalid' },
+  SECURE_PROXY_IP_BLOCKED: { level: 'error', description: 'The target IP address is blocked' },
+  SECURE_PROXY_IP_NOT_ALLOWED: { level: 'error', description: 'The target IP address is not in the allowlist' },
+  SECURE_PROXY_NOT_FOUND: { level: 'error', description: 'The secure proxy use case was not found' },
+  SECURE_PROXY_UNAVAILABLE: { level: 'error', description: 'Secure proxy service is unavailable' },
+  SIGNATURE_VERIFICATION_FAILED: { level: 'error', description: 'Request signature could not be verified' },
+  SIGNATURE_VERIFICATION_UNAVAILABLE: {
+    level: 'error',
+    description: 'The file service could not be reached to verify the request signature',
+  },
+  SOFT_DELETED_ENTITY_MATCHED: {
+    level: 'warning',
+    description:
+      'A soft-deleted entity matched the unique ID — it will be resurrected on upsert, or referenced as-is by a relation. Investigate why the ERP source is sending events for a deleted entity.',
+  },
+  STEP_DISABLED: {
+    level: 'error',
+    description:
+      'A request step\'s "run this step when" expression returned false, so this step and every step after it were skipped. This is the configuration working as written, not a fault.',
+  },
+  TIMEOUT: { level: 'error', description: 'The operation timed out' },
+  UNIQUE_ID_MULTIPLE_MATCHES: { level: 'error', description: 'Multiple entities matched the unique ID' },
+  UNIQUE_ID_NOT_IN_SCHEMA: {
+    level: 'error',
+    description: 'The unique ID attribute is not defined in the entity schema',
+  },
+  UNKNOWN_ERROR: { level: 'error', description: 'An unexpected error occurred during processing' },
+  USE_CASE_DISABLED: { level: 'error', description: 'The use case is currently disabled' },
+  USE_CASE_INVALID_TYPE: { level: 'error', description: 'The use case type is invalid or unsupported' },
+  USE_CASE_MISSING_CONFIG: { level: 'error', description: 'The use case is missing required configuration' },
+  USE_CASE_NOT_FOUND: { level: 'error', description: 'The use case could not be found' },
+  WEBHOOK_DELIVERED: { level: 'success', description: 'Webhook was delivered successfully' },
+};
+
+/**
+ * Describes any code seen on a monitoring event, including the `HTTP_{status}`
+ * family and codes this package predates. Returns `undefined` only for a code it
+ * cannot place at all, so callers can render a sensible fallback.
+ */
+export function describeMonitoringCode(code: string): MonitoringCodeMeta | undefined {
+  const known = (MONITORING_CODES as Record<string, MonitoringCodeMeta>)[code];
+  if (known) return known;
+
+  if (HTTP_STATUS_CODE_PATTERN.test(code)) {
+    return {
+      level: HTTP_STATUS_CODE_FAMILY.level,
+      description: HTTP_STATUS_CODE_FAMILY.description,
+    };
+  }
+
+  return undefined;
+}

--- a/clients/integration-toolkit-client/src/index.ts
+++ b/clients/integration-toolkit-client/src/index.ts
@@ -1,6 +1,7 @@
 export type { OpenAPIClient, OpenAPIClientAxios, Document } from 'openapi-client-axios';
 
 export * from './client';
+export * from './codes';
 export * from './openapi';
 
 // Export the full OpenAPI specification

--- a/clients/integration-toolkit-client/src/openapi.d.ts
+++ b/clients/integration-toolkit-client/src/openapi.d.ts
@@ -5728,6 +5728,22 @@ declare namespace Components {
                 ...RelationUniqueIdField[]
             ];
         }
+        /**
+         * The monitoring code taxonomy — every code the Integration Toolkit itself emits,
+         * with a fixed level (see the published code reference at
+         * https://docs.epilot.io/docs/integrations/integration-toolkit/monitoring/codes).
+         *
+         * This schema exists so consumers can import the union as a type. It is
+         * deliberately NOT applied to `MonitoringEventV2.code` or to the query filter:
+         * alongside these, the secure proxy emits an unbounded `HTTP_{status}` family for
+         * an upstream refusal, so constraining those fields to this enum would reject a
+         * legitimate value — `code` stays a plain string there on purpose.
+         *
+         * Kept in lock-step with the `MonitoringErrorCode` taxonomy in erp-utils by
+         * `monitoring-code-enum.test.ts`, which fails if the two diverge.
+         *
+         */
+        export type MonitoringCode = "ACK_CONFIRMED" | "ACK_PENDING" | "ACK_TIMEOUT" | "ATTACHMENT_NOT_FOUND" | "ATTRIBUTE_TYPE_MISMATCH" | "DEPRECATED_ENDPOINT" | "DIRECT_ENTITY_NOT_ALLOWED" | "DIRECT_PAYLOAD_INVALID" | "DIRECT_VERSION_UNSUPPORTED" | "DUPLICATE_EVENT" | "ENTITY_CREATED" | "ENTITY_DELETED" | "ENTITY_NO_OP" | "ENTITY_REFERENCE_NOT_FOUND" | "ENTITY_UPDATED" | "EVENT_NOT_CONFIGURED" | "EXTERNAL_API_ERROR" | "EXTERNAL_ERROR" | "EXTERNAL_INFO" | "EXTERNAL_SUCCESS" | "EXTERNAL_WARNING" | "FAN_OUT_EMPTY" | "FAN_OUT_INVALID_RESULT" | "FILE_EXTRACTION_FAILED" | "FILE_FETCH_FAILED" | "FILE_PROXY_OK" | "FILE_PROXY_UPLOADED" | "FILE_PROXY_UPLOAD_ENQUEUED" | "FILE_PROXY_UPLOAD_FAILED" | "FILE_PROXY_UPLOAD_RETRYING" | "FILE_TOO_LARGE" | "INTEGRATION_NOT_FOUND" | "INVALID_METER_READING_ATTRIBUTES" | "LOOKUP_UNMAPPED" | "MALFORMED_PAYLOAD" | "MAPPING_EXPRESSION_FAILED" | "METERING_API_ERROR" | "METER_READING_DELETED" | "METER_READING_GROUP_FAILED" | "METER_READING_GROUP_RETRYING" | "METER_READING_UPSERTED" | "MISSING_REQUIRED_PARAM" | "MISSING_UNIQUE_IDENTIFIERS" | "MSG_ACKED" | "MSG_DEAD_LETTERED" | "MSG_ENQUEUED" | "MSG_EXPIRED_UNPOLLED" | "MSG_HEAD_BLOCKED" | "OAUTH2_TOKEN_FAILURE" | "PAYLOAD_TOO_LARGE" | "PRUNE_SCOPE_COMPLETED" | "PRUNE_SCOPE_PARTIAL_FAILURE" | "RECURSION_DEPTH_EXCEEDED" | "RELATION_REF_ITEM_NOT_FOUND" | "RELATION_REF_VALUE_UNDEFINED" | "REQUIRED_PARAM_MISSING" | "SECURE_PROXY_DISABLED" | "SECURE_PROXY_DOMAIN_BLOCKED" | "SECURE_PROXY_DOMAIN_NOT_ALLOWED" | "SECURE_PROXY_ERROR" | "SECURE_PROXY_INVALID_CONFIG" | "SECURE_PROXY_INVALID_TYPE" | "SECURE_PROXY_INVALID_URL" | "SECURE_PROXY_IP_BLOCKED" | "SECURE_PROXY_IP_NOT_ALLOWED" | "SECURE_PROXY_NOT_FOUND" | "SECURE_PROXY_UNAVAILABLE" | "SIGNATURE_VERIFICATION_FAILED" | "SIGNATURE_VERIFICATION_UNAVAILABLE" | "SOFT_DELETED_ENTITY_MATCHED" | "STEP_DISABLED" | "TIMEOUT" | "UNIQUE_ID_MULTIPLE_MATCHES" | "UNIQUE_ID_NOT_IN_SCHEMA" | "UNKNOWN_ERROR" | "USE_CASE_DISABLED" | "USE_CASE_INVALID_TYPE" | "USE_CASE_MISSING_CONFIG" | "USE_CASE_NOT_FOUND" | "WEBHOOK_DELIVERED";
         export interface MonitoringEventV2 {
             /**
              * Unique monitoring event ID
@@ -5760,9 +5776,9 @@ declare namespace Components {
             /**
              * Event outcome level
              */
-            level: "success" | "error" | "skipped" | "warning";
+            level: "success" | "error" | "info" | "warning";
             /**
-             * Taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502). Empty for success.
+             * Taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502). Empty for success. One of `MonitoringCode`, or an `HTTP_{status}` family value from the secure proxy — which is why this is a string rather than that enum.
              */
             code?: string;
             /**
@@ -5878,9 +5894,13 @@ declare namespace Components {
              */
             warning_count: number;
             /**
-             * Number of skipped events
+             * Always 0. The v2 pipeline has no `skipped` level; v1 `skipped` is normalised to `info`. Retained for backward compatibility — use `info_count`.
              */
             skipped_count: number;
+            /**
+             * Number of info-level events (ACK lifecycle, poll-queue MSG_*, duplicate events, fan-out anchors). Info events are counted in `total_events` but are excluded from `success_rate`.
+             */
+            info_count: number;
             /**
              * Number of ACK_TIMEOUT events (acknowledgement timed out)
              */
@@ -6991,9 +7011,9 @@ declare namespace Components {
             /**
              * Filter by event level
              */
-            level?: "success" | "error" | "skipped" | "warning";
+            level?: "success" | "error" | "info" | "warning";
             /**
-             * Filter by taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502)
+             * Filter by taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502). Accepts any `MonitoringCode` value, or an `HTTP_{status}` family value.
              */
             code?: string;
             /**
@@ -7816,9 +7836,13 @@ declare namespace Components {
              */
             warning_count: number;
             /**
-             * Number of skipped events in the breakdown item
+             * Always 0. The v2 pipeline has no `skipped` level; v1 `skipped` is normalised to `info`. Retained for backward compatibility — use `info_count`.
              */
             skipped_count: number;
+            /**
+             * Number of info-level events in the breakdown item
+             */
+            info_count: number;
             /**
              * Total events in the breakdown item
              */
@@ -7867,9 +7891,13 @@ declare namespace Components {
              */
             warning_count?: number;
             /**
-             * Number of skipped events in the bucket
+             * Always 0. The v2 pipeline has no `skipped` level; v1 `skipped` is normalised to `info`. Retained for backward compatibility — use `info_count`.
              */
             skipped_count?: number;
+            /**
+             * Number of info-level events in the bucket
+             */
+            info_count?: number;
             /**
              * Total events in the bucket
              */
@@ -11678,6 +11706,7 @@ export type MeterReadingPruneScopeConfig = Components.Schemas.MeterReadingPruneS
 export type MeterReadingPruneScopeUpdate = Components.Schemas.MeterReadingPruneScopeUpdate;
 export type MeterReadingUpdate = Components.Schemas.MeterReadingUpdate;
 export type MeterUniqueIdsConfig = Components.Schemas.MeterUniqueIdsConfig;
+export type MonitoringCode = Components.Schemas.MonitoringCode;
 export type MonitoringEventV2 = Components.Schemas.MonitoringEventV2;
 export type MonitoringStats = Components.Schemas.MonitoringStats;
 export type MonitoringStatsV2 = Components.Schemas.MonitoringStatsV2;

--- a/clients/integration-toolkit-client/src/openapi.json
+++ b/clients/integration-toolkit-client/src/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Integration Toolkit API",
-    "version": "1.29.1",
+    "version": "1.31.0",
     "description": "API for integrating with external systems in a standardised way."
   },
   "tags": [
@@ -11816,14 +11816,14 @@
             "enum": [
               "success",
               "error",
-              "skipped",
+              "info",
               "warning"
             ],
             "description": "Filter by event level"
           },
           "code": {
             "type": "string",
-            "description": "Filter by taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502)"
+            "description": "Filter by taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502). Accepts any `MonitoringCode` value, or an `HTTP_{status}` family value."
           },
           "event_id": {
             "type": "string",
@@ -12023,6 +12023,92 @@
           }
         }
       },
+      "MonitoringCode": {
+        "type": "string",
+        "description": "The monitoring code taxonomy — every code the Integration Toolkit itself emits,\nwith a fixed level (see the published code reference at\nhttps://docs.epilot.io/docs/integrations/integration-toolkit/monitoring/codes).\n\nThis schema exists so consumers can import the union as a type. It is\ndeliberately NOT applied to `MonitoringEventV2.code` or to the query filter:\nalongside these, the secure proxy emits an unbounded `HTTP_{status}` family for\nan upstream refusal, so constraining those fields to this enum would reject a\nlegitimate value — `code` stays a plain string there on purpose.\n\nKept in lock-step with the `MonitoringErrorCode` taxonomy in erp-utils by\n`monitoring-code-enum.test.ts`, which fails if the two diverge.\n",
+        "enum": [
+          "ACK_CONFIRMED",
+          "ACK_PENDING",
+          "ACK_TIMEOUT",
+          "ATTACHMENT_NOT_FOUND",
+          "ATTRIBUTE_TYPE_MISMATCH",
+          "DEPRECATED_ENDPOINT",
+          "DIRECT_ENTITY_NOT_ALLOWED",
+          "DIRECT_PAYLOAD_INVALID",
+          "DIRECT_VERSION_UNSUPPORTED",
+          "DUPLICATE_EVENT",
+          "ENTITY_CREATED",
+          "ENTITY_DELETED",
+          "ENTITY_NO_OP",
+          "ENTITY_REFERENCE_NOT_FOUND",
+          "ENTITY_UPDATED",
+          "EVENT_NOT_CONFIGURED",
+          "EXTERNAL_API_ERROR",
+          "EXTERNAL_ERROR",
+          "EXTERNAL_INFO",
+          "EXTERNAL_SUCCESS",
+          "EXTERNAL_WARNING",
+          "FAN_OUT_EMPTY",
+          "FAN_OUT_INVALID_RESULT",
+          "FILE_EXTRACTION_FAILED",
+          "FILE_FETCH_FAILED",
+          "FILE_PROXY_OK",
+          "FILE_PROXY_UPLOADED",
+          "FILE_PROXY_UPLOAD_ENQUEUED",
+          "FILE_PROXY_UPLOAD_FAILED",
+          "FILE_PROXY_UPLOAD_RETRYING",
+          "FILE_TOO_LARGE",
+          "INTEGRATION_NOT_FOUND",
+          "INVALID_METER_READING_ATTRIBUTES",
+          "LOOKUP_UNMAPPED",
+          "MALFORMED_PAYLOAD",
+          "MAPPING_EXPRESSION_FAILED",
+          "METERING_API_ERROR",
+          "METER_READING_DELETED",
+          "METER_READING_GROUP_FAILED",
+          "METER_READING_GROUP_RETRYING",
+          "METER_READING_UPSERTED",
+          "MISSING_REQUIRED_PARAM",
+          "MISSING_UNIQUE_IDENTIFIERS",
+          "MSG_ACKED",
+          "MSG_DEAD_LETTERED",
+          "MSG_ENQUEUED",
+          "MSG_EXPIRED_UNPOLLED",
+          "MSG_HEAD_BLOCKED",
+          "OAUTH2_TOKEN_FAILURE",
+          "PAYLOAD_TOO_LARGE",
+          "PRUNE_SCOPE_COMPLETED",
+          "PRUNE_SCOPE_PARTIAL_FAILURE",
+          "RECURSION_DEPTH_EXCEEDED",
+          "RELATION_REF_ITEM_NOT_FOUND",
+          "RELATION_REF_VALUE_UNDEFINED",
+          "REQUIRED_PARAM_MISSING",
+          "SECURE_PROXY_DISABLED",
+          "SECURE_PROXY_DOMAIN_BLOCKED",
+          "SECURE_PROXY_DOMAIN_NOT_ALLOWED",
+          "SECURE_PROXY_ERROR",
+          "SECURE_PROXY_INVALID_CONFIG",
+          "SECURE_PROXY_INVALID_TYPE",
+          "SECURE_PROXY_INVALID_URL",
+          "SECURE_PROXY_IP_BLOCKED",
+          "SECURE_PROXY_IP_NOT_ALLOWED",
+          "SECURE_PROXY_NOT_FOUND",
+          "SECURE_PROXY_UNAVAILABLE",
+          "SIGNATURE_VERIFICATION_FAILED",
+          "SIGNATURE_VERIFICATION_UNAVAILABLE",
+          "SOFT_DELETED_ENTITY_MATCHED",
+          "STEP_DISABLED",
+          "TIMEOUT",
+          "UNIQUE_ID_MULTIPLE_MATCHES",
+          "UNIQUE_ID_NOT_IN_SCHEMA",
+          "UNKNOWN_ERROR",
+          "USE_CASE_DISABLED",
+          "USE_CASE_INVALID_TYPE",
+          "USE_CASE_MISSING_CONFIG",
+          "USE_CASE_NOT_FOUND",
+          "WEBHOOK_DELIVERED"
+        ]
+      },
       "MonitoringEventV2": {
         "type": "object",
         "required": [
@@ -12077,14 +12163,14 @@
             "enum": [
               "success",
               "error",
-              "skipped",
+              "info",
               "warning"
             ],
             "description": "Event outcome level"
           },
           "code": {
             "type": "string",
-            "description": "Taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502). Empty for success."
+            "description": "Taxonomy code (e.g. OAUTH2_TOKEN_FAILURE, HTTP_502). Empty for success. One of `MonitoringCode`, or an `HTTP_{status}` family value from the secure proxy — which is why this is a string rather than that enum."
           },
           "message": {
             "type": "string",
@@ -12172,7 +12258,8 @@
           "success_count",
           "error_count",
           "warning_count",
-          "skipped_count"
+          "skipped_count",
+          "info_count"
         ],
         "properties": {
           "total_events": {
@@ -12193,7 +12280,12 @@
           },
           "skipped_count": {
             "type": "integer",
-            "description": "Number of skipped events"
+            "deprecated": true,
+            "description": "Always 0. The v2 pipeline has no `skipped` level; v1 `skipped` is normalised to `info`. Retained for backward compatibility — use `info_count`."
+          },
+          "info_count": {
+            "type": "integer",
+            "description": "Number of info-level events (ACK lifecycle, poll-queue MSG_*, duplicate events, fan-out anchors). Info events are counted in `total_events` but are excluded from `success_rate`."
           },
           "ack_timeout_count": {
             "type": "integer",
@@ -12279,6 +12371,7 @@
           "error_count",
           "warning_count",
           "skipped_count",
+          "info_count",
           "total_count"
         ],
         "properties": {
@@ -12311,7 +12404,12 @@
           },
           "skipped_count": {
             "type": "integer",
-            "description": "Number of skipped events in the breakdown item"
+            "deprecated": true,
+            "description": "Always 0. The v2 pipeline has no `skipped` level; v1 `skipped` is normalised to `info`. Retained for backward compatibility — use `info_count`."
+          },
+          "info_count": {
+            "type": "integer",
+            "description": "Number of info-level events in the breakdown item"
           },
           "total_count": {
             "type": "integer",
@@ -12345,7 +12443,12 @@
           },
           "skipped_count": {
             "type": "integer",
-            "description": "Number of skipped events in the bucket"
+            "deprecated": true,
+            "description": "Always 0. The v2 pipeline has no `skipped` level; v1 `skipped` is normalised to `info`. Retained for backward compatibility — use `info_count`."
+          },
+          "info_count": {
+            "type": "integer",
+            "description": "Number of info-level events in the bucket"
           },
           "total_count": {
             "type": "integer",


### PR DESCRIPTION
Makes `@epilot/integration-toolkit-client` the distribution point for the monitoring code taxonomy, so consumers import it instead of hand-copying it.

## Why

The level and operator-facing description for every monitoring code lived **only in `epilot360-integration-hub`** — a frontend was the source of truth for a backend taxonomy. Consequences:

- 11 `SECURE_PROXY_*` codes existed nowhere else. Both producers emitted them as bare string literals, and the code even said so in a comment.
- 6 codes had **no description at all** (all four `EXTERNAL_*`, `STEP_DISABLED`, `INTEGRATION_NOT_FOUND`) and rendered blank in the UI.

`erp-integration-api` now owns them, where a code without a description is a **compile error**, and emits a CI-asserted snapshot. This package turns that into a published module.

## What's here

- **`src/codes.ts`** — generated by `npm run codes:local`. Exports `MONITORING_CODES` (level + description per code) and `describeMonitoringCode()`, which also resolves the `HTTP_{status}` family and returns `undefined` for anything it can't place, so callers render a fallback rather than a blank cell.
- **The code union is not redefined here.** It comes from the spec's new `MonitoringCode` enum via `./openapi`, so there's one definition of the list; `codes.ts` only aliases it locally (re-exporting collides).
- **`src/codes.test.ts`** pins the catalog against that enum. The two are refreshed by *different* commands (`codes:local` vs `openapi:local`), so shipping an inconsistent pair is the realistic failure mode — now caught.
- The generator formats its own output, so regenerating never shows up as a formatting diff.

Bundled spec refreshed to **1.31.0**, which carries the corrected v2 level enum (`info`, not `skipped`), `info_count`, and the `MonitoringCode` enum.

## Note on why `MonitoringCode` isn't applied to the `code` fields

The secure proxy emits an unbounded `HTTP_{status}` family alongside the taxonomy. `$ref`-ing the enum onto `MonitoringEventV2.code` or the query filter would reject a legitimate `HTTP_502` under openapi-backend's request validation — exactly the bug the `skipped`/`info` mismatch just caused. Those fields stay strings on purpose, and a test in erp-integration-api asserts they are never `$ref`'d.

Upstream: `integration-toolkit-api` main — `fd09f5d`, `2746cb2`, `69a2799`.

Next: `epilot360-integration-hub` takes this dependency and drops its hand-copied `CODE_DESCRIPTIONS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)