### PR TITLE
refactor(access-token-client): drop origin from contact identification tokens

### DIFF
--- a/clients/access-token-client/CHANGELOG.md
+++ b/clients/access-token-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @epilot/access-token-client
 
+## 1.6.0
+
+### Minor Changes
+
+- Remove `origin` from `ContactIdentificationTokenParameters` and from the token item, along with the `PortalOrigin` type. The token carries `portal_id`, and the consuming API resolves the origin from that portal's config.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/clients/access-token-client/package.json
+++ b/clients/access-token-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@epilot/access-token-client",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Client for epilot Access Token API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/clients/access-token-client/src/openapi.d.ts
+++ b/clients/access-token-client/src/openapi.d.ts
@@ -47,7 +47,6 @@ declare namespace Components {
              * 5da0a718-c822-403d-9f5d-20d4584e0528
              */
             ContactId;
-            origin?: /* Portal origin the token assumes, so the bearer is permission-masked the same way the corresponding portal role is. */ PortalOrigin;
             allowed_operations?: /**
              * openapi operationIds the token may call. Enforced by the API that consumes the token, which must additionally deny any operation not on this list. Baked into the token at issue time so widening the consumer's own allowlist later cannot retroactively widen a token that is already in circulation.
              * example:
@@ -221,7 +220,6 @@ declare namespace Components {
              * website-journeys
              */
             surface_id: string;
-            origin?: /* Portal origin the token assumes, so the bearer is permission-masked the same way the corresponding portal role is. */ PortalOrigin;
             allowed_operations: /**
              * openapi operationIds the token may call. Enforced by the API that consumes the token, which must additionally deny any operation not on this list. Baked into the token at issue time so widening the consumer's own allowlist later cannot retroactively widen a token that is already in circulation.
              * example:
@@ -258,10 +256,6 @@ declare namespace Components {
          * Portal ID for access token type "portal"
          */
         export type PortalId = string;
-        /**
-         * Portal origin the token assumes, so the bearer is permission-masked the same way the corresponding portal role is.
-         */
-        export type PortalOrigin = "END_CUSTOMER_PORTAL" | "INSTALLER_PORTAL";
         export interface PortalPreviewTokenParameters {
             name: /**
              * Human readable name for access token
@@ -341,7 +335,6 @@ declare namespace Paths {
                  * 5da0a718-c822-403d-9f5d-20d4584e0528
                  */
                 Components.Schemas.ContactId;
-                origin?: /* Portal origin the token assumes, so the bearer is permission-masked the same way the corresponding portal role is. */ Components.Schemas.PortalOrigin;
                 allowed_operations?: /**
                  * openapi operationIds the token may call. Enforced by the API that consumes the token, which must additionally deny any operation not on this list. Baked into the token at issue time so widening the consumer's own allowlist later cannot retroactively widen a token that is already in circulation.
                  * example:
@@ -959,7 +952,6 @@ export type ContactIdentificationTokenParameters = Components.Schemas.ContactIde
 export type ExpiresIn = Components.Schemas.ExpiresIn;
 export type JourneyTokenParameters = Components.Schemas.JourneyTokenParameters;
 export type PortalId = Components.Schemas.PortalId;
-export type PortalOrigin = Components.Schemas.PortalOrigin;
 export type PortalPreviewTokenParameters = Components.Schemas.PortalPreviewTokenParameters;
 export type PortalTokenParameters = Components.Schemas.PortalTokenParameters;
 export type PortalUserId = Components.Schemas.PortalUserId;

--- a/clients/access-token-client/src/openapi.json
+++ b/clients/access-token-client/src/openapi.json
@@ -94,7 +94,6 @@
                     "portal_id": "portal_abc123",
                     "contact_id": "5da0a718-c822-403d-9f5d-20d4584e0528",
                     "surface_id": "website-journeys",
-                    "origin": "END_CUSTOMER_PORTAL",
                     "allowed_operations": [
                       "getContact",
                       "getContracts"
@@ -665,14 +664,6 @@
         "description": "Contact entity ID for access token type \"contact_identification\"",
         "example": "5da0a718-c822-403d-9f5d-20d4584e0528"
       },
-      "PortalOrigin": {
-        "type": "string",
-        "enum": [
-          "END_CUSTOMER_PORTAL",
-          "INSTALLER_PORTAL"
-        ],
-        "description": "Portal origin the token assumes, so the bearer is permission-masked the same way the corresponding portal role is."
-      },
       "AllowedOperations": {
         "type": "array",
         "description": "openapi operationIds the token may call. Enforced by the API that consumes the token, which must additionally deny any operation not on this list. Baked into the token at issue time so widening the consumer's own allowlist later cannot retroactively widen a token that is already in circulation.",
@@ -928,9 +919,6 @@
             "description": "Portal surface the token is issued for (see `surfaces` on the portal config in customer-portal-api). Carried as the `custom:surface_id` claim; the consuming API resolves the surface's data access from the portal config on every request.",
             "example": "website-journeys"
           },
-          "origin": {
-            "$ref": "#/components/schemas/PortalOrigin"
-          },
           "allowed_operations": {
             "$ref": "#/components/schemas/AllowedOperations"
           },
@@ -983,9 +971,6 @@
           },
           "contact_id": {
             "$ref": "#/components/schemas/ContactId"
-          },
-          "origin": {
-            "$ref": "#/components/schemas/PortalOrigin"
           },
           "allowed_operations": {
             "$ref": "#/components/schemas/AllowedOperations"


### PR DESCRIPTION
## Summary
- Regenerate `@epilot/access-token-client` from the access-token-api spec on `claude/contact-identification-drop-origin` (access-token-api !98).
- Removes `origin` from `ContactIdentificationTokenParameters` and from the token item, along with the now-unused `PortalOrigin` type. The token carries `portal_id`, and the consuming API resolves the origin from that portal's config, so the field was a second source of truth.
- Version bumped to 1.6.0 with a changelog entry; the package is published by hand from this version, so no pending changeset is left behind.

## Notes
- Merge after access-token-api !98, so the published client never advertises a field the API rejects.

## Test plan
- [ ] CI green
- [ ] `npm publish` of the 1.6.0 tarball, then bump the dependency in customer-portal-api

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAwMMEindALKZ1yt6tWCyg

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAwMMEindALKZ1yt6tWCyg)_